### PR TITLE
Version 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Diagrams (2.1.1) - 2021-05-25
+
+### Fixed
+
+- Exception when navigating to the Options page (#95).
+- Portless links not deleted when node is deleted (#96).
+
 ## Diagrams (2.1.0) - 2021-03-24
 
 ## Added
@@ -17,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Diagrams (2.0.0) - 2021-03-24
 
-## Added
+### Added
 
 - `GroupUngrouped` event (not the greatest name 😄)
 - Touch events `TouchStart`, `TouchMove` and `TouchEnd`
@@ -91,7 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 	- This also works for groups, since groups are nodes
 - Unit tests
 
-## Changed
+### Changed
 
 - Renamed `DiagramManager` to `Diagram`
 - Remove need to specify `Name` in diagram's `CascadingValue`
@@ -127,7 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only render links when ports/nodes are initialized (position and/or size received)
 	- This will avoid the weird flicker where links show at (0, 0) then move to the correct position
 
-## Fixed
+### Fixed
 
 - Remove links when groups are removed
 - Issue where links are clickable outside the visible stroke
@@ -147,30 +154,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Diagrams [1.5.2] - 2021-01-18
 
-## Fixed
+### Fixed
 
 - Missing MouseUp event on links.
 
 ## Diagrams [1.5.1] - 2021-01-09
 
-## Added
+### Added
 
 - `AddGroup`: add an instance of a group to the diagram.
 - Custom group documentation/demo.
 
-## Fixed
+### Fixed
 
 - Clicking the canvas in the Events demo throws an exception.
 
 ## Diagrams [1.5.0] - 2021-01-05
 
-## Added
+### Added
 
 - The ability to have ports on groups.
 - **EXPERIMENTAL/INCOMPLETE** Nested groups. Since `GroupModel` now inherits `NodeMode`, it became possible to have nested groups, but there are still problems with the order of links between groups.
 - A `Class` parameter to `GroupContainer`.
 
-## Changed
+### Changed
 
 - Only rerender groups when necessary.
 - Receiving the same size from `ResizeObserver` doesn't trigger a rerender anymore.
@@ -178,14 +185,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid rerendering ports when their parent node is moving.
 - Padding is now handled in `GroupModel` instead of `GroupContainer` (UI). This is because the padding is necessary to have accurate size/position in the group model directly.
 
-## Fixed
+### Fixed
 
 - Use `@key` when rendering the list of groups. Not using it caused big/weird render times.
 - Groups not showing in Navigator/Overview.
 
 ## Diagrams [1.4.2] - 2020-12-30
 
-## Added
+### Added
 
 - Locked nodes now have a `locked` class and their cursor is changed to `pointer`.
 

--- a/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
+++ b/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
@@ -7,10 +7,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>zHaytam</Authors>
     <Description>A fully customizable and extensible all-purpose diagrams library for Blazor</Description>
-    <AssemblyVersion>2.1.0</AssemblyVersion>
-    <FileVersion>2.1.0</FileVersion>
+    <AssemblyVersion>2.1.1</AssemblyVersion>
+    <FileVersion>2.1.1</FileVersion>
     <RepositoryUrl>https://github.com/zHaytam/Blazor.Diagrams</RepositoryUrl>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <PackageId>Z.Blazor.Diagrams.Core</PackageId>
     <PackageTags>blazor diagrams diagramming svg drag</PackageTags>
     <Product>Z.Blazor.Diagrams.Core</Product>

--- a/src/Blazor.Diagrams.Core/DiagramOptions.cs
+++ b/src/Blazor.Diagrams.Core/DiagramOptions.cs
@@ -85,8 +85,11 @@ namespace Blazor.Diagrams.Core
     /// </summary>
     public class DiagramConstraintsOptions
     {
+        [Description("Decide if a node can/should be deleted")]
         public Func<NodeModel, bool> ShouldDeleteNode { get; set; } = _ => true;
+        [Description("Decide if a link can/should be deleted")]
         public Func<BaseLinkModel, bool> ShouldDeleteLink { get; set; } = _ => true;
+        [Description("Decide if a group can/should be deleted")]
         public Func<GroupModel, bool> ShouldDeleteGroup { get; set; } = _ => true;
     }
 }

--- a/src/Blazor.Diagrams.Core/Layers/NodeLayer.cs
+++ b/src/Blazor.Diagrams.Core/Layers/NodeLayer.cs
@@ -15,6 +15,7 @@ namespace Blazor.Diagrams.Core.Layers
         protected override void OnItemRemoved(NodeModel node)
         {
             Diagram.Links.Remove(node.AllLinks.ToList());
+            Diagram.Links.Remove(node.Links.ToList());
             node.Group?.RemoveChild(node);
         }
     }

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -5,11 +5,11 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <Authors>zHaytam</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <AssemblyVersion>2.1.0</AssemblyVersion>
-    <FileVersion>2.1.0</FileVersion>
+    <AssemblyVersion>2.1.1</AssemblyVersion>
+    <FileVersion>2.1.1</FileVersion>
     <RepositoryUrl>https://github.com/zHaytam/Blazor.Diagrams</RepositoryUrl>
     <Description>A fully customizable and extensible all-purpose diagrams library for Blazor</Description>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>blazor diagrams diagramming svg drag</PackageTags>
     <PackageId>Z.Blazor.Diagrams</PackageId>


### PR DESCRIPTION
### Fixed

- Exception when navigating to the Options page (#95).
- Portless links not deleted when node is deleted (#96).