### PR TITLE
Version 2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Diagrams (2.1.5) - 2021-08-30
+
+### Fixed
+
+- Links not being removed from the node after they have been removed from the Links layer. (fixes #136)
+- A regression in `ZoomToFit`. (fixes #138)
+
 ## Diagrams (2.1.4) - 2021-08-29
 
 ### Added

--- a/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
+++ b/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
@@ -7,10 +7,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>zHaytam</Authors>
     <Description>A fully customizable and extensible all-purpose diagrams library for Blazor</Description>
-    <AssemblyVersion>2.1.4</AssemblyVersion>
-    <FileVersion>2.1.4</FileVersion>
+    <AssemblyVersion>2.1.5</AssemblyVersion>
+    <FileVersion>2.1.5</FileVersion>
     <RepositoryUrl>https://github.com/zHaytam/Blazor.Diagrams</RepositoryUrl>
-    <Version>2.1.4</Version>
+    <Version>2.1.5</Version>
     <PackageId>Z.Blazor.Diagrams.Core</PackageId>
     <PackageTags>blazor diagrams diagramming svg drag</PackageTags>
     <Product>Z.Blazor.Diagrams.Core</Product>

--- a/src/Blazor.Diagrams.Core/Diagram.cs
+++ b/src/Blazor.Diagrams.Core/Diagram.cs
@@ -293,15 +293,16 @@ namespace Blazor.Diagrams.Core
             var minX = bounds.Left - margin;
             var minY = bounds.Top - margin;
 
+            SuspendRefresh = true;
+
             var xf = Container.Width / width;
             var yf = Container.Height / height;
+            SetZoom(Math.Min(xf, yf));
 
             var nx = Container.Left + Pan.X + minX * Zoom;
             var ny = Container.Top + Pan.Y + minY * Zoom;
-
-            SuspendRefresh = true;
-            SetZoom(Math.Min(xf, yf));
             UpdatePan(Container.Left - nx, Container.Top - ny);
+
             SuspendRefresh = false;
             Refresh();
         }

--- a/src/Blazor.Diagrams.Core/Layers/LinkLayer.cs
+++ b/src/Blazor.Diagrams.Core/Layers/LinkLayer.cs
@@ -38,8 +38,8 @@ namespace Blazor.Diagrams.Core.Layers
             }
             else
             {
-                link.SourceNode.AddLink(link);
-                link.TargetNode?.AddLink(link);
+                link.SourceNode.RemoveLink(link);
+                link.TargetNode?.RemoveLink(link);
             }
 
             link.SourceNode.Group?.Refresh();

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -5,11 +5,11 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <Authors>zHaytam</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <AssemblyVersion>2.1.4</AssemblyVersion>
-    <FileVersion>2.1.4</FileVersion>
+    <AssemblyVersion>2.1.5</AssemblyVersion>
+    <FileVersion>2.1.5</FileVersion>
     <RepositoryUrl>https://github.com/zHaytam/Blazor.Diagrams</RepositoryUrl>
     <Description>A fully customizable and extensible all-purpose diagrams library for Blazor</Description>
-    <Version>2.1.4</Version>
+    <Version>2.1.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>blazor diagrams diagramming svg drag</PackageTags>
     <PackageId>Z.Blazor.Diagrams</PackageId>

--- a/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
@@ -41,8 +41,8 @@ namespace Blazor.Diagrams.Core.Tests
 
             // Assert
             diagram.Zoom.Should().BeApproximately(7.68, 0.001);
-            diagram.Pan.X.Should().Be(-40);
-            diagram.Pan.Y.Should().Be(-40);
+            diagram.Pan.X.Should().Be(-307.2);
+            diagram.Pan.Y.Should().Be(-307.2);
         }
 
         [Fact]
@@ -61,8 +61,8 @@ namespace Blazor.Diagrams.Core.Tests
 
             // Assert
             diagram.Zoom.Should().BeApproximately(7.68, 0.001);
-            diagram.Pan.X.Should().Be(-40);
-            diagram.Pan.Y.Should().Be(-40);
+            diagram.Pan.X.Should().Be(-307.2);
+            diagram.Pan.Y.Should().Be(-307.2);
         }
 
         [Fact]


### PR DESCRIPTION
### Fixed

- Links not being removed from the node after they have been removed from the Links layer. (fixes #136)
- A regression in `ZoomToFit`. (fixes #138)