### PR TITLE
Version 2.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Diagrams (2.1.6) - 2021-10-31
+
+### Fixed
+
+- `ZoomBehavior` using new zoom before Clamp to set Pan. (fixes #141)
+- `PanChanged` not triggering when zooming with the mouse wheel.
+- Zoom value decreasing when the mouse wheel delta is zero.
+- Ports aren't refreshed when links are added in `OnInitializedAsync`. (fixes #111)
+
 ## Diagrams (2.1.5) - 2021-08-30
 
 ### Fixed

--- a/src/Blazor.Diagrams.Core/Behaviors/ZoomBehavior.cs
+++ b/src/Blazor.Diagrams.Core/Behaviors/ZoomBehavior.cs
@@ -15,7 +15,7 @@ namespace Blazor.Diagrams.Core.Behaviors
 
         private void Diagram_Wheel(WheelEventArgs e)
         {
-            if (Diagram.Container == null)
+            if (Diagram.Container == null || e.DeltaY == 0)
                 return;
 
             if (!Diagram.Options.Zoom.Enabled)
@@ -26,7 +26,6 @@ namespace Blazor.Diagrams.Core.Behaviors
             var deltaY = Diagram.Options.Zoom.Inverse ? e.DeltaY * -1 : e.DeltaY;
             var newZoom = deltaY > 0 ? oldZoom * scale : oldZoom / scale;
             newZoom = Math.Clamp(newZoom, Diagram.Options.Zoom.Minimum, Diagram.Options.Zoom.Maximum);
-            Console.WriteLine($"{e.DeltaY}, {oldZoom}, {newZoom}");
 
             if (newZoom < 0 || newZoom == Diagram.Zoom)
                 return;

--- a/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
+++ b/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
@@ -7,10 +7,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>zHaytam</Authors>
     <Description>A fully customizable and extensible all-purpose diagrams library for Blazor</Description>
-    <AssemblyVersion>2.1.5</AssemblyVersion>
-    <FileVersion>2.1.5</FileVersion>
+    <AssemblyVersion>2.1.6</AssemblyVersion>
+    <FileVersion>2.1.6</FileVersion>
     <RepositoryUrl>https://github.com/zHaytam/Blazor.Diagrams</RepositoryUrl>
-    <Version>2.1.5</Version>
+    <Version>2.1.6</Version>
     <PackageId>Z.Blazor.Diagrams.Core</PackageId>
     <PackageTags>blazor diagrams diagramming svg drag</PackageTags>
     <Product>Z.Blazor.Diagrams.Core</Product>

--- a/src/Blazor.Diagrams.Core/Diagram.cs
+++ b/src/Blazor.Diagrams.Core/Diagram.cs
@@ -65,7 +65,7 @@ namespace Blazor.Diagrams.Core
         public LinkLayer Links { get; }
         public IReadOnlyList<GroupModel> Groups => _groups;
         public Rectangle? Container { get; internal set; }
-        public Point Pan { get; internal set; } = Point.Zero;
+        public Point Pan { get; private set; } = Point.Zero;
         public double Zoom { get; private set; } = 1;
         public DiagramOptions Options { get; }
         public bool SuspendRefresh { get; set; }
@@ -304,6 +304,13 @@ namespace Blazor.Diagrams.Core
             UpdatePan(Container.Left - nx, Container.Top - ny);
 
             SuspendRefresh = false;
+            Refresh();
+        }
+
+        public void SetPan(double x, double y)
+        {
+            Pan = new Point(x, y);
+            PanChanged?.Invoke();
             Refresh();
         }
 

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -5,11 +5,11 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <Authors>zHaytam</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <AssemblyVersion>2.1.5</AssemblyVersion>
-    <FileVersion>2.1.5</FileVersion>
+    <AssemblyVersion>2.1.6</AssemblyVersion>
+    <FileVersion>2.1.6</FileVersion>
     <RepositoryUrl>https://github.com/zHaytam/Blazor.Diagrams</RepositoryUrl>
     <Description>A fully customizable and extensible all-purpose diagrams library for Blazor</Description>
-    <Version>2.1.5</Version>
+    <Version>2.1.6</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>blazor diagrams diagramming svg drag</PackageTags>
     <PackageId>Z.Blazor.Diagrams</PackageId>


### PR DESCRIPTION
### Fixed

- `ZoomBehavior` using new zoom before Clamp to set Pan. (fixes #141)
- `PanChanged` not triggering when zooming with the mouse wheel.
- Zoom value decreasing when the mouse wheel delta is zero.
- Ports aren't refreshed when links are added in `OnInitializedAsync`. (fixes #111)