### PR TITLE
Add LinkRemoved action

### DIFF
--- a/src/Blazor.Diagrams.Core/Models/PortModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/PortModel.cs
@@ -1,5 +1,6 @@
 ﻿using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models.Base;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -27,6 +28,7 @@ namespace Blazor.Diagrams.Core.Models
             Size = size ?? Size.Zero;
         }
 
+        public event Action<BaseLinkModel> LinkRemoved;
         public NodeModel Parent { get; }
         public PortAlignment Alignment { get; }
         public Point Position { get; set; }
@@ -55,6 +57,10 @@ namespace Blazor.Diagrams.Core.Models
 
         internal void AddLink(BaseLinkModel link) => _links.Add(link);
 
-        internal void RemoveLink(BaseLinkModel link) => _links.Remove(link);
+        internal void RemoveLink(BaseLinkModel link)
+        {
+            _links.Remove(link);
+            LinkRemoved.Invoke(link);
+        }
     }
 }


### PR DESCRIPTION
I needed to know when a Link is removed from a Port, so I can update the object linked to my model (a question) to remove the link to - in this case - the answer.
I could not find a way to do that with the current version, so I added this event.
<img width="359" alt="image" src="https://user-images.githubusercontent.com/211138/152987926-ab812ead-a697-4929-8d0e-01c31ea9f4cc.png">
<img width="350" alt="image" src="https://user-images.githubusercontent.com/211138/152987964-dba8fa06-aa85-41d6-8766-fa22a75bb97b.png">
