### PR TITLE
Zoom clamp

### DIFF
--- a/src/Blazor.Diagrams.Core/Diagram.cs
+++ b/src/Blazor.Diagrams.Core/Diagram.cs
@@ -40,7 +40,6 @@ namespace Blazor.Diagrams.Core
         public event Action? PanChanged;
         public event Action? ZoomChanged;
         public event Action? ContainerChanged;
-        public const double MIN_ZOOM_VALUE = 0.1;
 
         public Diagram(DiagramOptions? options = null)
         {
@@ -325,9 +324,10 @@ namespace Blazor.Diagrams.Core
         public void SetZoom(double newZoom)
         {
             if (newZoom <= 0)
-            {
-                newZoom = MIN_ZOOM_VALUE;
-            }
+                newZoom = Options.Zoom.Minimum;
+            else if (newZoom > Options.Zoom.Maximum)
+                newZoom = Options.Zoom.Maximum;
+
             Zoom = newZoom;
             ZoomChanged?.Invoke();
             Refresh();

--- a/src/Blazor.Diagrams.Core/Diagram.cs
+++ b/src/Blazor.Diagrams.Core/Diagram.cs
@@ -40,6 +40,7 @@ namespace Blazor.Diagrams.Core
         public event Action? PanChanged;
         public event Action? ZoomChanged;
         public event Action? ContainerChanged;
+        public const double MIN_ZOOM_VALUE = 0.01;
 
         public Diagram(DiagramOptions? options = null)
         {
@@ -323,6 +324,10 @@ namespace Blazor.Diagrams.Core
 
         public void SetZoom(double newZoom)
         {
+            if (newZoom <= 0)
+            {
+                newZoom = MIN_ZOOM_VALUE;
+            }
             Zoom = newZoom;
             ZoomChanged?.Invoke();
             Refresh();

--- a/src/Blazor.Diagrams.Core/Diagram.cs
+++ b/src/Blazor.Diagrams.Core/Diagram.cs
@@ -326,8 +326,7 @@ namespace Blazor.Diagrams.Core
             if (newZoom <= 0)
                 throw new ArgumentException($"{nameof(newZoom)} cannot be equal or lower than 0");
 
-            if (Options.Zoom.Minimum <= 0)
-                throw new ArgumentException($"(Zoom Options) =>{nameof(Options.Zoom.Minimum)} cannot be equal or lower than 0");
+           
 
             if (newZoom < Options.Zoom.Minimum)
                 newZoom = Options.Zoom.Minimum;

--- a/src/Blazor.Diagrams.Core/Diagram.cs
+++ b/src/Blazor.Diagrams.Core/Diagram.cs
@@ -324,9 +324,15 @@ namespace Blazor.Diagrams.Core
         public void SetZoom(double newZoom)
         {
             if (newZoom <= 0)
+                throw new ArgumentException($"{nameof(newZoom)} cannot be equal or lower than 0");
+
+            if (Options.Zoom.Minimum <= 0)
+                throw new ArgumentException($"(Zoom Options) =>{nameof(Options.Zoom.Minimum)} cannot be equal or lower than 0");
+
+            if (newZoom < Options.Zoom.Minimum)
                 newZoom = Options.Zoom.Minimum;
-            else if (newZoom > Options.Zoom.Maximum)
-                newZoom = Options.Zoom.Maximum;
+           
+           
 
             Zoom = newZoom;
             ZoomChanged?.Invoke();

--- a/src/Blazor.Diagrams.Core/Diagram.cs
+++ b/src/Blazor.Diagrams.Core/Diagram.cs
@@ -40,7 +40,7 @@ namespace Blazor.Diagrams.Core
         public event Action? PanChanged;
         public event Action? ZoomChanged;
         public event Action? ContainerChanged;
-        public const double MIN_ZOOM_VALUE = 0.01;
+        public const double MIN_ZOOM_VALUE = 0.1;
 
         public Diagram(DiagramOptions? options = null)
         {

--- a/src/Blazor.Diagrams.Core/DiagramOptions.cs
+++ b/src/Blazor.Diagrams.Core/DiagramOptions.cs
@@ -60,11 +60,19 @@ namespace Blazor.Diagrams.Core
         [Description("Whether to inverse the zoom direction or not")]
         public bool Inverse { get; set; }
         [Description("Minimum value allowed")]
-        public double Minimum { get; set; } = 0.1;
+        public double Minimum { get { return _minimum; } set { SetMinimum(value); } }
+        private double _minimum = 0.1;
         [Description("Maximum value allowed")]
         public double Maximum { get; set; } = 2;
         [Description("Zoom Scale Factor. Should be between 1.01 and 2.  Default is 1.05.")]
         public double ScaleFactor { get; set; } = 1.05;
+
+        private void SetMinimum(double minValue)
+        {
+            if (minValue <= 0)
+                throw new ArgumentException($"(Zoom Options) =>{nameof(Minimum)} cannot be equal or lower than 0");
+            _minimum = minValue;
+        }
     }
 
     /// <summary>

--- a/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
@@ -91,5 +91,29 @@ namespace Blazor.Diagrams.Core.Tests
             zoomChanges.Should().Be(1);
             panChanges.Should().Be(1);
         }
+
+        [Theory]
+        [InlineData(-0.5)]
+        [InlineData(-0.00001)]
+        [InlineData(0)]
+        [InlineData(-3)]
+        public void Zoom_ShoulClampToMinimumValue(double zoomValue)
+        {
+            var diagram = new Diagram();
+            diagram.SetZoom(zoomValue);
+            Assert.Equal(diagram.Zoom, Diagram.MIN_ZOOM_VALUE);
+        }
+
+        [Theory]
+        [InlineData(0.000001)]
+        [InlineData(1)]
+        [InlineData(1.5)]
+        [InlineData(0.1)]
+        public void Zoom_SetZoom(double zoomValue)
+        {
+            var diagram = new Diagram();
+            diagram.SetZoom(zoomValue);
+            Assert.Equal(diagram.Zoom, zoomValue);
+        }
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
@@ -1,6 +1,7 @@
 ﻿using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
 using FluentAssertions;
+using System;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests
@@ -93,27 +94,23 @@ namespace Blazor.Diagrams.Core.Tests
         }
 
         [Theory]
-        [InlineData(-0.5)]
-        [InlineData(-0.00001)]
-        [InlineData(0)]
-        [InlineData(-3)]
+        [InlineData(0.001)]
+        [InlineData(0.1)]
         public void Zoom_ShoulClampToMinimumValue(double zoomValue)
         {
             var diagram = new Diagram();
             diagram.SetZoom(zoomValue);
-            Assert.Equal(diagram.Zoom, Diagram.MIN_ZOOM_VALUE);
+            Assert.Equal(diagram.Zoom, diagram.Options.Zoom.Minimum);
         }
 
         [Theory]
-        [InlineData(0.000001)]
-        [InlineData(1)]
-        [InlineData(1.5)]
-        [InlineData(0.1)]
-        public void Zoom_SetZoom(double zoomValue)
+        [InlineData(0)]
+        [InlineData(-0.1)]
+        [InlineData(-0.00001)]
+        public void Zoom_ThrowExceptionWehnLessThan0(double zoomValue)
         {
             var diagram = new Diagram();
-            diagram.SetZoom(zoomValue);
-            Assert.Equal(diagram.Zoom, zoomValue);
+            Assert.Throws<ArgumentException>(()=>diagram.SetZoom(zoomValue));
         }
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
@@ -107,10 +107,20 @@ namespace Blazor.Diagrams.Core.Tests
         [InlineData(0)]
         [InlineData(-0.1)]
         [InlineData(-0.00001)]
-        public void Zoom_ThrowExceptionWehnLessThan0(double zoomValue)
+        public void Zoom_ThrowExceptionWhenLessThan0(double zoomValue)
         {
             var diagram = new Diagram();
-            Assert.Throws<ArgumentException>(()=>diagram.SetZoom(zoomValue));
+            Assert.Throws<ArgumentException>(() => diagram.SetZoom(zoomValue));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-0.1)]
+        [InlineData(-0.00001)]
+        public void ZoomOptions_ThrowExceptionWhenLessThan0(double zoomValue)
+        {
+            var diagram = new Diagram();
+            Assert.Throws<ArgumentException>(() => diagram.Options.Zoom.Minimum = zoomValue);
         }
     }
 }


### PR DESCRIPTION
If the zoom value is 0 or lower, the diagram stop working properly.
To avoid this I have added checks on the setZoom function to ensure that the devs know that this is a limitation.