### PR TITLE
Grid snap to center

### DIFF
--- a/samples/SharedDemo/Demos/SnapToGrid.razor
+++ b/samples/SharedDemo/Demos/SnapToGrid.razor
@@ -14,12 +14,18 @@
         LayoutData.DataChanged();
     }
 }
+<div style="position: absolute; z-index: 9999;">
+    <div class="custom-control custom-checkbox ml-2">
+        <input id="snapToCenterCheckbox" type="checkbox" class="custom-control-input" @bind-value="BlazorDiagram.Options.GridSnapToCenter" />
+        <label class="custom-control-label" for="snapToCenterCheckbox">Toggle Snap To Center</label>
+    </div>
+</div>
 
 <CascadingValue Value="BlazorDiagram">
     <DiagramCanvas>
         <Widgets>
-            <NavigatorWidget Width="300" Height="200" DefaultStyle="true"></NavigatorWidget>
-            <GridWidget Size="50" Mode="GridMode.Line" ZoomThreshold="0.5"></GridWidget>
+            <NavigatorWidget Width="300" Height="200" Style="position: absolute; bottom: 15px; right: 15px; border: 1px solid black;"></NavigatorWidget>
+            <GridWidget Size="75" Mode="GridMode.Line" ZoomThreshold="0.5"></GridWidget>
         </Widgets>
     </DiagramCanvas>
 </CascadingValue>

--- a/samples/SharedDemo/Demos/SnapToGrid.razor
+++ b/samples/SharedDemo/Demos/SnapToGrid.razor
@@ -9,7 +9,7 @@
         base.OnInitialized();
 
         LayoutData.Title = "Snap to Grid";
-        LayoutData.Info = "This diagram has a grid size of 50, moving nodes will make them automatically snap.<br />" +
+        LayoutData.Info = "This diagram has a grid size of 75, moving nodes will make them automatically snap.<br />" +
                 "The background grid isn't added by Z.Blazor.Diagrams, in order for you to use whatever you want.";
         LayoutData.DataChanged();
     }

--- a/samples/SharedDemo/Demos/SnapToGrid.razor.cs
+++ b/samples/SharedDemo/Demos/SnapToGrid.razor.cs
@@ -10,7 +10,7 @@ namespace SharedDemo
     {
         protected readonly BlazorDiagram BlazorDiagram = new(new BlazorDiagramOptions
         {
-            GridSize = 50
+            GridSize = 75
         });
 
         protected override void OnInitialized()

--- a/samples/SharedDemo/Layouts/DemoLayout.razor
+++ b/samples/SharedDemo/Layouts/DemoLayout.razor
@@ -21,7 +21,7 @@
 
 @if (LayoutData.Info != null)
 {
-    <div class="floating alert alert-primary" role="alert">
+    <div class="floating alert alert-primary" style="z-index: 10000;" role="alert">
         <h4 class="alert-heading">@LayoutData.Title</h4>
         <p>@((MarkupString)LayoutData.Info)</p>
     </div>

--- a/src/Blazor.Diagrams.Core/Behaviors/DragMovablesBehavior.cs
+++ b/src/Blazor.Diagrams.Core/Behaviors/DragMovablesBehavior.cs
@@ -24,7 +24,7 @@ namespace Blazor.Diagrams.Core.Behaviors
 
         private void OnPointerDown(Model? model, PointerEventArgs e)
         {
-            if (model is not NodeModel)
+            if (model is not MovableModel)
                 return;
 
             _initialPositions.Clear();
@@ -32,6 +32,7 @@ namespace Blazor.Diagrams.Core.Behaviors
             {
                 if (sm is not MovableModel movable || movable.Locked)
                     continue;
+
                 var position = movable.Position;
                 if (Diagram.Options.GridSnapToCenter && movable is NodeModel node)
                 {

--- a/src/Blazor.Diagrams.Core/Options/DiagramOptions.cs
+++ b/src/Blazor.Diagrams.Core/Options/DiagramOptions.cs
@@ -3,6 +3,7 @@ namespace Blazor.Diagrams.Core.Options;
 public class DiagramOptions
 {
     public int? GridSize { get; set; }
+    public bool GridSnapToCenter { get; set; }
     public bool AllowMultiSelection { get; set; } = true;
     public bool AllowPanning { get; set; } = true;
     

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragMovablesBehaviorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragMovablesBehaviorTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Blazor.Diagrams.Core.Events;
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
+using Blazor.Diagrams.Core.Options;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -28,7 +29,34 @@ public class DragMovablesBehaviorTests
         // Assert
         nodeMock.Verify(n => n.SetPosition(50, 50), Times.Once);
     }
-    
+
+    [Theory]
+    [InlineData(false, 45, 45)]
+    [InlineData(true, 35, 35)]
+    public void Behavior_SnapToGrid_ShouldCallSetPosition(bool gridSnapToCenter, double deltaX, double deltaY)
+    {
+        // Arrange
+        var diagram = new TestDiagram(new DiagramOptions
+        {
+            GridSize = 15,
+            GridSnapToCenter = gridSnapToCenter
+        });
+        var nodeMock = new Mock<NodeModel>(Point.Zero);
+        var node = diagram.Nodes.Add(nodeMock.Object);
+        node.Size = new Size(50, 50);
+        node.Position = new Point(0, 0);
+        diagram.SelectModel(node, false);
+
+        // Act
+        diagram.TriggerPointerDown(node,
+            new PointerEventArgs(20, 20, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
+        diagram.TriggerPointerMove(null,
+            new PointerEventArgs(60, 60, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
+
+        // Assert
+        nodeMock.Verify(n => n.SetPosition(deltaX, deltaY), Times.Once);
+    }
+
     [Fact]
     public void Behavior_ShouldTriggerMoved()
     {

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragMovablesBehaviorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragMovablesBehaviorTests.cs
@@ -32,9 +32,9 @@ public class DragMovablesBehaviorTests
 
     [Theory]
     [InlineData(false, 0, 0, 45, 45)]
-    [InlineData(true, 0, 0, 50, 50)]
+    [InlineData(true, 0, 0, 35, 35)]
     [InlineData(false, 3, 3, 45, 45)]
-    [InlineData(true, 3, 3, 35, 35)]
+    [InlineData(true, 3, 3, 50, 50)]
     public void Behavior_SnapToGrid_ShouldCallSetPosition(bool gridSnapToCenter, double initialX, double initialY, double deltaX, double deltaY)
     {
         // Arrange

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragMovablesBehaviorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragMovablesBehaviorTests.cs
@@ -31,9 +31,11 @@ public class DragMovablesBehaviorTests
     }
 
     [Theory]
-    [InlineData(false, 45, 45)]
-    [InlineData(true, 35, 35)]
-    public void Behavior_SnapToGrid_ShouldCallSetPosition(bool gridSnapToCenter, double deltaX, double deltaY)
+    [InlineData(false, 0, 0, 45, 45)]
+    [InlineData(true, 0, 0, 50, 50)]
+    [InlineData(false, 3, 3, 45, 45)]
+    [InlineData(true, 3, 3, 35, 35)]
+    public void Behavior_SnapToGrid_ShouldCallSetPosition(bool gridSnapToCenter, double initialX, double initialY, double deltaX, double deltaY)
     {
         // Arrange
         var diagram = new TestDiagram(new DiagramOptions
@@ -43,11 +45,12 @@ public class DragMovablesBehaviorTests
         });
         var nodeMock = new Mock<NodeModel>(Point.Zero);
         var node = diagram.Nodes.Add(nodeMock.Object);
-        node.Size = new Size(50, 50);
-        node.Position = new Point(0, 0);
+        node.Size = new Size(20, 20);
+        node.Position = new Point(initialX, initialY);
         diagram.SelectModel(node, false);
 
         // Act
+        //Move 40px in X and Y
         diagram.TriggerPointerDown(node,
             new PointerEventArgs(20, 20, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
         diagram.TriggerPointerMove(null,

--- a/tests/Blazor.Diagrams.Core.Tests/TestDiagram.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/TestDiagram.cs
@@ -1,12 +1,14 @@
+#nullable enable
+using System;
 using Blazor.Diagrams.Core.Options;
 
 namespace Blazor.Diagrams.Core.Tests;
 
 public class TestDiagram : Diagram
 {
-    public TestDiagram()
+    public TestDiagram(DiagramOptions? options = null)
     {
-        Options = new DiagramOptions();
+        Options = options ?? new DiagramOptions();
     }
 
     public override DiagramOptions Options { get; }


### PR DESCRIPTION
- Added GridSnapToCenter to DiagramOptions
- In Drag Behavior, check the option to see if the snap point should be the Top Left (GridSnapToCenter = false) or center of the node (GridSnapToCenter = true).