### PR TITLE
Fix link hover stroke opacity

### DIFF
--- a/src/Blazor.Diagrams/Components/LinkWidget.razor.cs
+++ b/src/Blazor.Diagrams/Components/LinkWidget.razor.cs
@@ -23,7 +23,7 @@ public partial class LinkWidget
             builder.AddAttribute(3, "stroke-width", 12);
             builder.AddAttribute(4, "d", d);
             builder.AddAttribute(5, "stroke-linecap", "butt");
-            builder.AddAttribute(6, "stroke-opacity", _hovered ? 0.05 : 0);
+            builder.AddAttribute(6, "stroke-opacity", _hovered ? "0.05" : "0");
             builder.AddAttribute(7, "fill", "none");
             builder.AddAttribute(8, "onmouseenter", EventCallback.Factory.Create<MouseEventArgs>(this, OnMouseEnter));
             builder.AddAttribute(9, "onmouseleave", EventCallback.Factory.Create<MouseEventArgs>(this, OnMouseLeave));


### PR DESCRIPTION
The hover stroke opacity for links is not set correctly if the system language uses a `,` instead of a `.` for decimal points.  In this case the opacity will be set to `stroke-opacity="0,05"` which is interpetet as `1` by the browser. This results in an extremly width path.