### PR TITLE
fix null reference exception in Diagram Demo

### DIFF
--- a/docs/Diagram-Demo/Pages/Diagrams.razor
+++ b/docs/Diagram-Demo/Pages/Diagrams.razor
@@ -28,7 +28,7 @@ or it will not be rendered.
 </div>
 
 @code {
-  private Diagram Diagram { get; set; }
+  private BlazorDiagram Diagram { get; set; }
 
   protected override void OnInitialized()
   {


### PR DESCRIPTION
Fix a null reference exception error in the Diagram Demo when accessing the Diagrams tab:
the Diagram parameter for the DiagramCanvas is null due to difference in types (where DiagramCanvas expects a BlazorDiagram object but we are passing a Diagram object)

![image](https://github.com/Blazor-Diagrams/Blazor.Diagrams/assets/71658224/6d097b8f-7173-40ca-9c2a-69887f3c77a4)
