### PR TITLE
Fixing NullReference Exception and not updating nodes on demo site diagram

### DIFF
--- a/site/Site/Components/Landing/LandingShowcaseDiagram.razor.cs
+++ b/site/Site/Components/Landing/LandingShowcaseDiagram.razor.cs
@@ -76,7 +76,10 @@ public partial class LandingShowcaseDiagram
     private void OnLinkRemoved(BaseLinkModel link)
     {
         (link.Source.Model as PortModel)!.Parent.Refresh();
-        if (link.Target != null && link.Target.Model is PortModel portModel) portModel.Parent.Refresh();
+        if (link.Target is SinglePortAnchor anchor && anchor.Model is PortModel portModel)
+        {
+            portModel.Parent.Refresh();
+        }
         link.TargetChanged -= OnLinKTargetChanged;
     }
 }

--- a/site/Site/Components/Landing/LandingShowcaseDiagram.razor.cs
+++ b/site/Site/Components/Landing/LandingShowcaseDiagram.razor.cs
@@ -65,7 +65,7 @@ public partial class LandingShowcaseDiagram
         link.TargetChanged += OnLinKTargetChanged;
     }
 
-    private void OnLinKTargetChanged(BaseLinkModel link, Anchor? oldTarget, Anchor? newTarget)
+    private void OnLinKTargetChanged(BaseLinkModel link, Anchor oldTarget, Anchor newTarget)
     {
         // only refresh on the first time the link is attached
         if (oldTarget is PositionAnchor 

--- a/site/Site/Components/Landing/LandingShowcaseDiagram.razor.cs
+++ b/site/Site/Components/Landing/LandingShowcaseDiagram.razor.cs
@@ -67,7 +67,7 @@ public partial class LandingShowcaseDiagram
 
     private void OnLinKTargetChanged(BaseLinkModel link, Anchor? oldTarget, Anchor? newTarget)
     {
-        if (oldTarget == null && newTarget != null) // First attach
+        if (link.IsAttached && newTarget is not null)
         {
             (newTarget.Model as PortModel)!.Parent.Refresh();
         }

--- a/site/Site/Components/Landing/LandingShowcaseDiagram.razor.cs
+++ b/site/Site/Components/Landing/LandingShowcaseDiagram.razor.cs
@@ -76,7 +76,7 @@ public partial class LandingShowcaseDiagram
     private void OnLinkRemoved(BaseLinkModel link)
     {
         (link.Source.Model as PortModel)!.Parent.Refresh();
-        if (link.Target != null) (link.Target.Model as PortModel)!.Parent.Refresh();
+        if (link.Target != null && link.Target.Model is PortModel portModel) portModel.Parent.Refresh();
         link.TargetChanged -= OnLinKTargetChanged;
     }
 }

--- a/site/Site/Components/Landing/LandingShowcaseDiagram.razor.cs
+++ b/site/Site/Components/Landing/LandingShowcaseDiagram.razor.cs
@@ -67,9 +67,12 @@ public partial class LandingShowcaseDiagram
 
     private void OnLinKTargetChanged(BaseLinkModel link, Anchor? oldTarget, Anchor? newTarget)
     {
-        if (link.IsAttached && newTarget is not null)
+        // only refresh on the first time the link is attached
+        if (oldTarget is PositionAnchor 
+            && newTarget.Model is PortModel targetModel
+            && link.IsAttached)        
         {
-            (newTarget.Model as PortModel)!.Parent.Refresh();
+            targetModel.Parent.Refresh();
         }
     }
 


### PR DESCRIPTION
Fixing a null pointer exception on the demo site diagram, that happened when a link was drawn and released on anything else then a portmodel. Fixes #361.

Fixing the value of the nodes not updating, when the target of a link has changed, because the condition 
`oldTarget == null` being never valid.