### PR TITLE
Bugfix/#359 should delete constraint not checked on remove control

### DIFF
--- a/src/Blazor.Diagrams.Core/Controls/Default/RemoveControl.cs
+++ b/src/Blazor.Diagrams.Core/Controls/Default/RemoveControl.cs
@@ -23,18 +23,25 @@ public class RemoveControl : ExecutableControl
 
     public override Point? GetPosition(Model model) => _positionProvider.GetPosition(model);
 
-    public override ValueTask OnPointerDown(Diagram diagram, Model model, PointerEventArgs _)
+    public override async ValueTask OnPointerDown(Diagram diagram, Model model, PointerEventArgs _)
     {
         switch (model)
         {
+
             case NodeModel node:
-                diagram.Nodes.Remove(node);
+                if (await diagram.Options.Constraints.ShouldDeleteNode.Invoke(node))
+                {
+                    diagram.Nodes.Remove(node);
+                }
                 break;
             case BaseLinkModel link:
-                diagram.Links.Remove(link);
+                if (await diagram.Options.Constraints.ShouldDeleteLink.Invoke(link))
+                {
+                    diagram.Links.Remove(link);
+                }
                 break;
-        }
 
-        return ValueTask.CompletedTask;
+            
+        }
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Controls/RemoveControlTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Controls/RemoveControlTests.cs
@@ -1,0 +1,179 @@
+﻿using Blazor.Diagrams.Core.Controls.Default;
+using Blazor.Diagrams.Core.Events;
+using Blazor.Diagrams.Core.Geometry;
+using Blazor.Diagrams.Core.Models;
+using Blazor.Diagrams.Core.Models.Base;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Blazor.Diagrams.Core.Tests.Controls
+{
+    public class RemoveControlTests
+    {
+        public PointerEventArgs PointerEventArgs
+            => new(100, 100, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true);
+
+        [Fact]
+        public async Task OnPointerDown_NoConstraints_RemovesNode()
+        {
+            // Arrange
+            RemoveControl removeControl = new(0, 0);
+            Diagram diagram = new TestDiagram();
+            var nodeMock = new Mock<NodeModel>(Point.Zero);
+            var node = diagram.Nodes.Add(nodeMock.Object);
+
+            // Act
+            await removeControl.OnPointerDown(diagram, node, PointerEventArgs);
+
+            // Assert
+            Assert.Empty(diagram.Nodes);
+        }
+
+        [Fact]
+        public async Task OnPointerDown_ShouldDeleteNodeTrue_RemovesNode()
+        {
+            // Arrange
+            RemoveControl removeControl = new(0, 0);
+            Diagram diagram = new TestDiagram(
+                new Options.DiagramOptions
+                {
+                    Constraints =
+                    {
+                        ShouldDeleteNode = (node) => ValueTask.FromResult(true)
+                    }
+                });
+            var nodeMock = new Mock<NodeModel>(Point.Zero);
+            var node = diagram.Nodes.Add(nodeMock.Object);
+
+            // Act
+            await removeControl.OnPointerDown(diagram, node, PointerEventArgs);
+
+            // Assert
+            Assert.Empty(diagram.Nodes);
+        }
+
+        [Fact]
+        public async Task OnPointerDown_ShouldDeleteNodeFalse_KeepsNode()
+        {
+            // Arrange
+            RemoveControl removeControl = new(0, 0);
+            Diagram diagram = new TestDiagram(
+                new Options.DiagramOptions
+                {
+                    Constraints =
+                    {
+                        ShouldDeleteNode = (node) => ValueTask.FromResult(false)
+                    }
+                });
+            var nodeMock = new Mock<NodeModel>(Point.Zero);
+            var node = diagram.Nodes.Add(nodeMock.Object);
+
+            // Act
+            await removeControl.OnPointerDown(diagram, node, PointerEventArgs);
+
+            // Assert
+            Assert.Contains(node, diagram.Nodes);
+        }
+
+        [Fact]
+        public async Task OnPointerDown_NoConstraints_RemovesLink()
+        {
+            // Arrange
+            RemoveControl removeControl = new(0, 0);
+            Diagram diagram = new TestDiagram();
+
+            var node1 = new NodeModel(new Point(50, 50));
+            var node2 = new NodeModel(new Point(300, 300));
+            diagram.Nodes.Add(new[] { node1, node2 });
+            node1.AddPort(PortAlignment.Right);
+            node2.AddPort(PortAlignment.Left);
+
+            var link = new LinkModel(
+                    node1.GetPort(PortAlignment.Right)!,
+                    node2.GetPort(PortAlignment.Left)!
+                    );
+
+            diagram.Links.Add(link);
+
+            // Act
+            await removeControl.OnPointerDown(diagram, link, PointerEventArgs);
+
+            // Assert
+            Assert.Empty(diagram.Links);
+        }
+
+        [Fact]
+        public async Task OnPointerDown_ShouldDeleteLinkTrue_RemovesLink()
+        {
+            // Arrange
+            RemoveControl removeControl = new(0, 0);
+            Diagram diagram = new TestDiagram(
+                new Options.DiagramOptions
+                {
+                    Constraints =
+                    {
+                        ShouldDeleteLink = (node) => ValueTask.FromResult(true)
+                    }
+                });
+
+            var node1 = new NodeModel(new Point(50, 50));
+            var node2 = new NodeModel(new Point(300, 300));
+            diagram.Nodes.Add(new[] { node1, node2 });
+            node1.AddPort(PortAlignment.Right);
+            node2.AddPort(PortAlignment.Left);
+
+            var link = new LinkModel(
+                    node1.GetPort(PortAlignment.Right)!,
+                    node2.GetPort(PortAlignment.Left)!
+                    );
+
+            diagram.Links.Add(link);
+
+            // Act
+            await removeControl.OnPointerDown(diagram, link, PointerEventArgs);
+
+            // Assert
+            Assert.Empty(diagram.Links);
+        }
+
+        [Fact]
+        public async Task OnPointerDown_ShouldDeleteLinkFalse_KeepsLink()
+        {
+            // Arrange
+            RemoveControl removeControl = new(0, 0);
+            Diagram diagram = new TestDiagram(
+                new Options.DiagramOptions
+                {
+                    Constraints =
+                    {
+                        ShouldDeleteLink = (node) => ValueTask.FromResult(false)
+                    }
+                });
+
+            var node1 = new NodeModel(new Point(50, 50));
+            var node2 = new NodeModel(new Point(300, 300));
+            diagram.Nodes.Add(new[] { node1, node2 });
+            node1.AddPort(PortAlignment.Right);
+            node2.AddPort(PortAlignment.Left);
+
+            var link = new LinkModel(
+                    node1.GetPort(PortAlignment.Right)!,
+                    node2.GetPort(PortAlignment.Left)!
+                    );
+
+            diagram.Links.Add(link);
+
+            // Act
+            await removeControl.OnPointerDown(diagram, link, PointerEventArgs);
+
+            // Assert
+            Assert.Contains(link, diagram.Links);
+        }
+
+    }
+}

--- a/tests/Blazor.Diagrams.Core.Tests/Controls/RemoveControlTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Controls/RemoveControlTests.cs
@@ -175,5 +175,98 @@ namespace Blazor.Diagrams.Core.Tests.Controls
             Assert.Contains(link, diagram.Links);
         }
 
+        [Fact]
+        public async Task OnPointerDown_NoConstraints_RemovesGroup()
+        {
+            // Arrange
+            RemoveControl removeControl = new(0, 0);
+            Diagram diagram = new TestDiagram();
+
+            var node1 = new NodeModel(new Point(50, 50));
+            var node2 = new NodeModel(new Point(300, 300));
+            diagram.Nodes.Add(new[] { node1, node2 });
+            node1.AddPort(PortAlignment.Right);
+            node2.AddPort(PortAlignment.Left);
+
+            var group = new GroupModel(new[] { node1, node2 });
+
+
+            diagram.Groups.Add(group);
+
+            // Act
+            await removeControl.OnPointerDown(diagram, group, PointerEventArgs);
+
+            // Assert
+            Assert.Empty(diagram.Groups);
+            Assert.Empty(diagram.Nodes);
+        }
+
+        [Fact]
+        public async Task OnPointerDown_ShouldDeleteGroupTrue_RemovesGroup()
+        {
+            // Arrange
+            RemoveControl removeControl = new(0, 0);
+            Diagram diagram = new TestDiagram(
+                new Options.DiagramOptions
+                {
+                    Constraints =
+                    {
+                        ShouldDeleteGroup = (node) => ValueTask.FromResult(true)
+                    }
+                });
+
+            var node1 = new NodeModel(new Point(50, 50));
+            var node2 = new NodeModel(new Point(300, 300));
+            diagram.Nodes.Add(new[] { node1, node2 });
+            node1.AddPort(PortAlignment.Right);
+            node2.AddPort(PortAlignment.Left);
+
+            var group = new GroupModel(new[] { node1, node2 });
+
+
+            diagram.Groups.Add(group);
+
+            // Act
+            await removeControl.OnPointerDown(diagram, group, PointerEventArgs);
+
+            // Assert
+            Assert.Empty(diagram.Groups);
+            Assert.Empty(diagram.Nodes);
+        }
+
+        [Fact]
+        public async Task OnPointerDown_ShouldDeleteGroupFalse_KeepsGroup()
+        {
+            // Arrange
+            RemoveControl removeControl = new(0, 0);
+            Diagram diagram = new TestDiagram(
+                new Options.DiagramOptions
+                {
+                    Constraints =
+                    {
+                        ShouldDeleteGroup = (node) => ValueTask.FromResult(false)
+                    }
+                });
+
+            var node1 = new NodeModel(new Point(50, 50));
+            var node2 = new NodeModel(new Point(300, 300));
+            diagram.Nodes.Add(new[] { node1, node2 });
+            node1.AddPort(PortAlignment.Right);
+            node2.AddPort(PortAlignment.Left);
+
+            var group = new GroupModel(new[] { node1, node2 });
+
+
+            diagram.Groups.Add(group);
+
+            // Act
+            await removeControl.OnPointerDown(diagram, group, PointerEventArgs);
+
+            // Assert
+            Assert.Contains(group, diagram.Groups);
+            Assert.Contains(node1, diagram.Nodes);
+            Assert.Contains(node2, diagram.Nodes);
+        }
+
     }
 }


### PR DESCRIPTION
I have added a small fix for #359.

The RemoveControl is now checking if the "ShouldDelete" constraint is fulfilled before deleting node-models or links. 

I have actually prepared the same change for groups too, but not added it to the PR because the behavior is actually different for groups, depending on the children (should they be removed, what if they have constraints, ...).

The current behavior for groups is to use the same path as node models (because they effectively are), which means that they aren't deleted because they are not in the NodeLayer. Also they don't use the "ShouldDeleteGroup" constraint, but the "ShouldDeleteNode" constraint. 

Please let me know which group behavior you want to have implemented:

1. Delete checks the "ShouldDeleteGroup"-constraint and if fulfilled removing group from group layer
2. Checking the "ShouldDeleteGroup"-constraint and if fulfilled deleting group with all children recursively
3. A different behavior
4. No changes
