### PR TITLE
Added Classes to LinkRenderer

### DIFF
--- a/src/Blazor.Diagrams.Core/Models/Base/BaseLinkModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/Base/BaseLinkModel.cs
@@ -42,6 +42,8 @@ public abstract class BaseLinkModel : SelectableModel, IHasBounds, ILinkable
     public List<LinkLabelModel> Labels { get; } = new();
     public IReadOnlyList<BaseLinkModel> Links => _links;
 
+    public string Classes { get; set; } = "";
+
     public override void Refresh()
     {
         GeneratePath();

--- a/src/Blazor.Diagrams/Components/Renderers/LinkRenderer.cs
+++ b/src/Blazor.Diagrams/Components/Renderers/LinkRenderer.cs
@@ -48,6 +48,7 @@ public class LinkRenderer : ComponentBase, IDisposable
         var classes = new StringBuilder()
             .Append("diagram-link")
             .AppendIf(" attached", Link.IsAttached)
+            .AppendIf(" " + Link.Classes, !string.IsNullOrEmpty(Link.Classes))
             .ToString();
 
         builder.OpenElement(0, "g");


### PR DESCRIPTION
I added a "Classes" property to BaseLinkModel which is then used in the LinkRenderer. This allow users to add a css class to the <g> element of a link