### PR TITLE
Handle null Rectangle

### DIFF
--- a/src/Blazor.Diagrams.Core/Diagram.cs
+++ b/src/Blazor.Diagrams.Core/Diagram.cs
@@ -251,9 +251,9 @@ public abstract class Diagram
         Refresh();
     }
 
-    public void SetContainer(Rectangle newRect)
+    public void SetContainer(Rectangle? newRect)
     {
-        if (newRect.Equals(Container))
+        if (Equals(newRect, Container))
             return;
 
         Container = newRect;

--- a/src/Blazor.Diagrams/Components/Renderers/PortRenderer.cs
+++ b/src/Blazor.Diagrams/Components/Renderers/PortRenderer.cs
@@ -124,10 +124,17 @@ public class PortRenderer : ComponentBase, IDisposable
         var zoom = BlazorDiagram.Zoom;
         var pan = BlazorDiagram.Pan;
         var rect = await JSRuntime.GetBoundingClientRect(_element);
+        
+        if (rect is not null)
+        {
+            Port.Size = new Size(rect.Width / zoom, rect.Height / zoom);
 
-        Port.Size = new Size(rect.Width / zoom, rect.Height / zoom);
-        Port.Position = new Point((rect.Left - BlazorDiagram.Container.Left - pan.X) / zoom,
-            (rect.Top - BlazorDiagram.Container.Top - pan.Y) / zoom);
+            if (BlazorDiagram.Container is not null)
+            {
+                Port.Position = new Point((rect.Left - BlazorDiagram.Container.Left - pan.X) / zoom,
+                    (rect.Top - BlazorDiagram.Container.Top - pan.Y) / zoom);
+            }
+        }
 
         Port.Initialized = true;
         _updatingDimensions = false;

--- a/src/Blazor.Diagrams/Extensions/JSRuntimeExtensions.cs
+++ b/src/Blazor.Diagrams/Extensions/JSRuntimeExtensions.cs
@@ -8,7 +8,7 @@ namespace Blazor.Diagrams.Extensions;
 
 public static class JSRuntimeExtensions
 {
-    public static async Task<Rectangle> GetBoundingClientRect(this IJSRuntime jsRuntime, ElementReference element)
+    public static async Task<Rectangle?> GetBoundingClientRect(this IJSRuntime jsRuntime, ElementReference element)
     {
         return await jsRuntime.InvokeAsync<Rectangle>("ZBlazorDiagrams.getBoundingClientRect", element);
     }

--- a/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
@@ -122,4 +122,17 @@ public class DiagramTests
         var diagram = new TestDiagram();
         Assert.Throws<ArgumentException>(() => diagram.Options.Zoom.Minimum = zoomValue);
     }
+        
+    [Fact]
+    public void SetContainer_ShouldAcceptNullGracefully()
+    {
+        // Arrange
+        var diagram = new TestDiagram();
+
+        //Act
+        var exception = Record.Exception(() => diagram.SetContainer(null));
+
+        // Assert
+        exception.Should().BeNull();
+    }
 }

--- a/tests/Blazor.Diagrams.Tests/Components/Renderers/PortRendererTest.cs
+++ b/tests/Blazor.Diagrams.Tests/Components/Renderers/PortRendererTest.cs
@@ -1,0 +1,22 @@
+﻿using Blazor.Diagrams.Components.Renderers;
+using Blazor.Diagrams.Core.Models;
+using Bunit;
+using Xunit;
+
+namespace Blazor.Diagrams.Tests.Components.Renderers;
+
+public class PortRendererTest
+{
+    [Fact]
+    void UpdateDimensionsDoesNotCrashWithNullContainer()
+    {
+        using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        var node = new NodeModel();
+        var portModel = new PortModel(node, PortAlignment.Bottom);
+
+        var component = ctx.RenderComponent<PortRenderer>(parameters => parameters
+            .Add(n => n.Port, portModel)
+            .Add(n => n.BlazorDiagram, new BlazorDiagram()));
+    }
+}


### PR DESCRIPTION
Handle null rectangle gracefully so that diagram can render in unit test without JS.