### PR TITLE
Set diagram cursor conditionally

### DIFF
--- a/src/Blazor.Diagrams/Components/DiagramCanvas.razor
+++ b/src/Blazor.Diagrams/Components/DiagramCanvas.razor
@@ -1,5 +1,6 @@
 ﻿<div class="diagram-canvas @Class"
      tabindex="-1"
+     style="@Style"
      @ref="elementReference"
      @onpointerdown="OnPointerDown"
      @onpointermove="OnPointerMove"

--- a/src/Blazor.Diagrams/Components/DiagramCanvas.razor.cs
+++ b/src/Blazor.Diagrams/Components/DiagramCanvas.razor.cs
@@ -12,6 +12,7 @@ public partial class DiagramCanvas : IDisposable
 {
     private DotNetObjectReference<DiagramCanvas>? _reference;
     private bool _shouldRender;
+    private string? Style;
 
     protected ElementReference elementReference;
 
@@ -52,6 +53,7 @@ public partial class DiagramCanvas : IDisposable
 
         _reference = DotNetObjectReference.Create(this);
         BlazorDiagram.Changed += OnDiagramChanged;
+        Style = BlazorDiagram.Options.AllowPanning ? "cursor: grab;" : "cursor: default;";
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Blazor.Diagrams/Components/DiagramCanvas.razor.cs
+++ b/src/Blazor.Diagrams/Components/DiagramCanvas.razor.cs
@@ -53,7 +53,7 @@ public partial class DiagramCanvas : IDisposable
 
         _reference = DotNetObjectReference.Create(this);
         BlazorDiagram.Changed += OnDiagramChanged;
-        Style = BlazorDiagram.Options.AllowPanning ? "cursor: grab;" : "cursor: default;";
+        Style = BlazorDiagram.Options.AllowPanning ? "cursor: grab; cursor: -webkit-grab;" : "cursor: default;";
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Blazor.Diagrams/wwwroot/style.css
+++ b/src/Blazor.Diagrams/wwwroot/style.css
@@ -4,8 +4,6 @@
     position: relative;
     outline: none;
     overflow: hidden;
-    cursor: -webkit-grab;
-    cursor: grab;
     touch-action: none;
 }
 

--- a/tests/Blazor.Diagrams.Tests/Components/DiagramCursorTests.cs
+++ b/tests/Blazor.Diagrams.Tests/Components/DiagramCursorTests.cs
@@ -22,10 +22,9 @@ namespace Blazor.Diagrams.Core.Tests.Behaviors
             var cut = ctx.RenderComponent<DiagramCanvas>(parameters => parameters
             .Add(n => n.BlazorDiagram, diagram));
             var diagramCanvas = cut.Find(".diagram-canvas");
-            var canvasStyle = diagramCanvas.GetStyle().CssText;
 
             // Assert
-            canvasStyle.Should().Contain("cursor: grab");
+            diagramCanvas.ToMarkup().Should().Contain("cursor: grab; cursor: -webkit-grab;");
         }
 
         [Fact]

--- a/tests/Blazor.Diagrams.Tests/Components/DiagramCursorTests.cs
+++ b/tests/Blazor.Diagrams.Tests/Components/DiagramCursorTests.cs
@@ -1,0 +1,57 @@
+﻿using AngleSharp.Css.Dom;
+using AngleSharp.Dom;
+using Blazor.Diagrams.Components;
+using Blazor.Diagrams.Core;
+using Blazor.Diagrams.Core.Geometry;
+using Bunit;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Blazor.Diagrams.Core.Tests.Behaviors
+{
+    public class DiagramCursorTests
+    {
+        [Fact]
+        public void Behavior_WhenPanningOptionIsAllowed_CursorShouldBeGrab()
+        {
+            // Arrange
+            using var ctx = new TestContext();
+            var diagram = new BlazorDiagram();
+            diagram.Options.AllowPanning = true;
+            ctx.JSInterop.Setup<Rectangle>("ZBlazorDiagrams.getBoundingClientRect", _ => true);
+
+            // Act
+            var cut = ctx.RenderComponent<DiagramCanvas>(parameters => parameters
+            .Add(n => n.BlazorDiagram, diagram));
+            var diagramCanvas = cut.Find(".diagram-canvas");
+            var canvasStyle = diagramCanvas.GetStyle().CssText;
+
+            // Assert
+            canvasStyle.Should().Contain("cursor: grab");
+        }
+
+        [Fact]
+        public void Behavior_WhenPanningOptionIsNotAllowed_CursorShouldBeDefault()
+        {
+            // Arrange
+            using var ctx = new TestContext();
+            var diagram = new BlazorDiagram();
+            diagram.Options.AllowPanning = false;
+            ctx.JSInterop.Setup<Rectangle>("ZBlazorDiagrams.getBoundingClientRect", _ => true);
+
+            // Act
+            var cut = ctx.RenderComponent<DiagramCanvas>(parameters => parameters
+            .Add(n => n.BlazorDiagram, diagram));
+            var diagramCanvas = cut.Find(".diagram-canvas");
+            var canvasStyle = diagramCanvas.GetStyle().CssText;
+
+            // Assert
+            canvasStyle.Should().Contain("cursor: default");
+        }
+    }
+}

--- a/tests/Blazor.Diagrams.Tests/Components/DiagramCursorTests.cs
+++ b/tests/Blazor.Diagrams.Tests/Components/DiagramCursorTests.cs
@@ -1,15 +1,8 @@
 ﻿using AngleSharp.Css.Dom;
-using AngleSharp.Dom;
 using Blazor.Diagrams.Components;
-using Blazor.Diagrams.Core;
 using Blazor.Diagrams.Core.Geometry;
 using Bunit;
 using FluentAssertions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests.Behaviors


### PR DESCRIPTION
If the diagram does not have AllowPanning set to true then the cursor will not be a hand and instead will be the default pointer