### PR TITLE
Link dblclick segmentable

### DIFF
--- a/src/Blazor.Diagrams.Core/Models/Base/BaseLinkModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/Base/BaseLinkModel.cs
@@ -82,16 +82,16 @@ public abstract class BaseLinkModel : SelectableModel, IHasBounds, ILinkable
         VertexAdded?.Invoke(this, vex);
         Refresh();
         return vex;
-	}
+    }
 
-	public void RemoveVertex(LinkVertexModel vertex)
-	{
+    public void RemoveVertex(LinkVertexModel vertex)
+    {
         Vertices.Remove(vertex);
-		VertexRemoved?.Invoke(this, vertex);
-		Refresh();
-	}
+        VertexRemoved?.Invoke(this, vertex);
+        Refresh();
+    }
 
-	public void SetSource(Anchor anchor)
+    public void SetSource(Anchor anchor)
     {
         ArgumentNullException.ThrowIfNull(anchor, nameof(anchor));
 

--- a/src/Blazor.Diagrams.Core/Models/Base/BaseLinkModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/Base/BaseLinkModel.cs
@@ -71,6 +71,7 @@ public abstract class BaseLinkModel : SelectableModel, IHasBounds, ILinkable
         var vertex = new LinkVertexModel(this, position);
         Vertices.Add(vertex);
         VertexAdded?.Invoke(this, vertex);
+        Refresh();
         return vertex;
     }
 
@@ -87,7 +88,6 @@ public abstract class BaseLinkModel : SelectableModel, IHasBounds, ILinkable
 	{
         Vertices.Remove(vertex);
 		VertexRemoved?.Invoke(this, vertex);
-
 		Refresh();
 	}
 

--- a/src/Blazor.Diagrams.Core/Models/Base/BaseLinkModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/Base/BaseLinkModel.cs
@@ -14,6 +14,8 @@ public abstract class BaseLinkModel : SelectableModel, IHasBounds, ILinkable
     public event Action<BaseLinkModel, Anchor, Anchor>? SourceChanged;
     public event Action<BaseLinkModel, Anchor, Anchor>? TargetChanged;
     public event Action<BaseLinkModel>? TargetAttached;
+    public event Action<BaseLinkModel, LinkVertexModel> VertexAdded;
+    public event Action<BaseLinkModel, LinkVertexModel> VertexRemoved;
 
     protected BaseLinkModel(Anchor source, Anchor target)
     {
@@ -38,6 +40,7 @@ public abstract class BaseLinkModel : SelectableModel, IHasBounds, ILinkable
     public LinkMarker? SourceMarker { get; set; }
     public LinkMarker? TargetMarker { get; set; }
     public bool Segmentable { get; set; } = false;
+    public bool DoubleClickToSegment { get; set; } = false;
     public List<LinkVertexModel> Vertices { get; } = new();
     public List<LinkLabelModel> Labels { get; } = new();
     public IReadOnlyList<BaseLinkModel> Links => _links;
@@ -67,10 +70,28 @@ public abstract class BaseLinkModel : SelectableModel, IHasBounds, ILinkable
     {
         var vertex = new LinkVertexModel(this, position);
         Vertices.Add(vertex);
+        VertexAdded?.Invoke(this, vertex);
         return vertex;
     }
 
-    public void SetSource(Anchor anchor)
+    public LinkVertexModel InsertVertex(Point? position, int index)
+    {
+        var vex = new LinkVertexModel(this, position);
+        Vertices.Insert(index, vex);
+        VertexAdded?.Invoke(this, vex);
+        Refresh();
+        return vex;
+	}
+
+	public void RemoveVertex(LinkVertexModel vertex)
+	{
+        Vertices.Remove(vertex);
+		VertexRemoved?.Invoke(this, vertex);
+
+		Refresh();
+	}
+
+	public void SetSource(Anchor anchor)
     {
         ArgumentNullException.ThrowIfNull(anchor, nameof(anchor));
 

--- a/src/Blazor.Diagrams.Core/Models/Base/BaseLinkModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/Base/BaseLinkModel.cs
@@ -14,8 +14,8 @@ public abstract class BaseLinkModel : SelectableModel, IHasBounds, ILinkable
     public event Action<BaseLinkModel, Anchor, Anchor>? SourceChanged;
     public event Action<BaseLinkModel, Anchor, Anchor>? TargetChanged;
     public event Action<BaseLinkModel>? TargetAttached;
-    public event Action<BaseLinkModel, LinkVertexModel> VertexAdded;
-    public event Action<BaseLinkModel, LinkVertexModel> VertexRemoved;
+    public event Action<BaseLinkModel, LinkVertexModel>? VertexAdded;
+    public event Action<BaseLinkModel, LinkVertexModel>? VertexRemoved;
 
     protected BaseLinkModel(Anchor source, Anchor target)
     {

--- a/src/Blazor.Diagrams/Components/LinkWidget.razor.cs
+++ b/src/Blazor.Diagrams/Components/LinkWidget.razor.cs
@@ -28,30 +28,30 @@ public partial class LinkWidget
             builder.AddAttribute(9, "onmouseleave", EventCallback.Factory.Create<MouseEventArgs>(this, OnMouseLeave));
             builder.AddAttribute(10, "onpointerdown", EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.PointerEventArgs>(this, e => OnPointerDown(e, index)));
             builder.AddAttribute(10, "ondblclick", EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, e => OnPointerDoubleClick(e, index)));
-			builder.AddEventStopPropagationAttribute(11, "onpointerdown", Link.Segmentable);
+            builder.AddEventStopPropagationAttribute(11, "onpointerdown", Link.Segmentable);
             builder.CloseElement();
         };
     }
 
-	private void OnPointerDown(PointerEventArgs e, int index)
-	{
-		if (!Link.Segmentable || Link.DoubleClickToSegment)
-			return;
+    private void OnPointerDown(PointerEventArgs e, int index)
+    {
+        if (!Link.Segmentable || Link.DoubleClickToSegment)
+            return;
 
-		var vertex = CreateVertex(e.ClientX, e.ClientY, index);
-		BlazorDiagram.TriggerPointerDown(vertex, e.ToCore());
-	}
+        var vertex = CreateVertex(e.ClientX, e.ClientY, index);
+        BlazorDiagram.TriggerPointerDown(vertex, e.ToCore());
+    }
 
-	private void OnPointerDoubleClick(MouseEventArgs e, int index)
-	{
-		if (!Link.Segmentable || !Link.DoubleClickToSegment)
-			return;
+    private void OnPointerDoubleClick(MouseEventArgs e, int index)
+    {
+        if (!Link.Segmentable || !Link.DoubleClickToSegment)
+            return;
 
-		var vertex = CreateVertex(e.ClientX, e.ClientY, index);
-		BlazorDiagram.TriggerPointerDoubleClick(vertex, e.ToCore());
-	}
+        var vertex = CreateVertex(e.ClientX, e.ClientY, index);
+        BlazorDiagram.TriggerPointerDoubleClick(vertex, e.ToCore());
+    }
 
-	private void OnMouseEnter(MouseEventArgs e)
+    private void OnMouseEnter(MouseEventArgs e)
     {
         _hovered = true;
     }

--- a/src/Blazor.Diagrams/Components/LinkWidget.razor.cs
+++ b/src/Blazor.Diagrams/Components/LinkWidget.razor.cs
@@ -27,21 +27,31 @@ public partial class LinkWidget
             builder.AddAttribute(8, "onmouseenter", EventCallback.Factory.Create<MouseEventArgs>(this, OnMouseEnter));
             builder.AddAttribute(9, "onmouseleave", EventCallback.Factory.Create<MouseEventArgs>(this, OnMouseLeave));
             builder.AddAttribute(10, "onpointerdown", EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.PointerEventArgs>(this, e => OnPointerDown(e, index)));
-            builder.AddEventStopPropagationAttribute(11, "onpointerdown", Link.Segmentable);
+            builder.AddAttribute(10, "ondblclick", EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, e => OnPointerDoubleClick(e, index)));
+			builder.AddEventStopPropagationAttribute(11, "onpointerdown", Link.Segmentable);
             builder.CloseElement();
         };
     }
 
-    private void OnPointerDown(PointerEventArgs e, int index)
-    {
-        if (!Link.Segmentable)
-            return;
+	private void OnPointerDown(PointerEventArgs e, int index)
+	{
+		if (!Link.Segmentable || Link.DoubleClickToSegment)
+			return;
 
-        var vertex = CreateVertex(e.ClientX, e.ClientY, index);
-        BlazorDiagram.TriggerPointerDown(vertex, e.ToCore());
-    }
+		var vertex = CreateVertex(e.ClientX, e.ClientY, index);
+		BlazorDiagram.TriggerPointerDown(vertex, e.ToCore());
+	}
 
-    private void OnMouseEnter(MouseEventArgs e)
+	private void OnPointerDoubleClick(MouseEventArgs e, int index)
+	{
+		if (!Link.Segmentable || !Link.DoubleClickToSegment)
+			return;
+
+		var vertex = CreateVertex(e.ClientX, e.ClientY, index);
+		BlazorDiagram.TriggerPointerDoubleClick(vertex, e.ToCore());
+	}
+
+	private void OnMouseEnter(MouseEventArgs e)
     {
         _hovered = true;
     }
@@ -54,9 +64,7 @@ public partial class LinkWidget
     private LinkVertexModel CreateVertex(double clientX, double clientY, int index)
     {
         var rPt = BlazorDiagram.GetRelativeMousePoint(clientX, clientY);
-        var vertex = new LinkVertexModel(Link, rPt);
-        Link.Vertices.Insert(index, vertex);
-        Link.Refresh();
+        var vertex = Link.InsertVertex(rPt, index);
         return vertex;
     }
 }

--- a/src/Blazor.Diagrams/Components/Renderers/LinkVertexRenderer.cs
+++ b/src/Blazor.Diagrams/Components/Renderers/LinkVertexRenderer.cs
@@ -89,7 +89,6 @@ public class LinkVertexRenderer : ComponentBase, IDisposable
 
     private void OnDoubleClick(MouseEventArgs e)
     {
-        Vertex.Parent.Vertices.Remove(Vertex);
-        Vertex.Parent.Refresh();
+        Vertex.Parent.RemoveVertex(Vertex);
     }
 }


### PR DESCRIPTION
I added a new option to make link segmentable only with double click instead of single clicks.

I also took the opportunity to add events for vertex added and removed, since there was no way of knowing the vertex changed other than cycling through all of the everytime there is a "Changed" event