### PR TITLE
Controls layer refactor

### DIFF
--- a/site/Site/Pages/Documentation/Controls/Customization.razor
+++ b/site/Site/Pages/Documentation/Controls/Customization.razor
@@ -156,6 +156,7 @@ public class AlertControl : ExecutableControl
         cNode2.Title = "Hover on me";
         _cDiagram.Controls.AddFor(cNode1, ControlsType.OnSelection).Add(new NodeInformationControl());
         _cDiagram.Controls.AddFor(cNode2, ControlsType.OnHover).Add(new NodeInformationControl());
+        _cDiagram.Controls.AddFor(cNode2, ControlsType.AlwaysOn).Add(new NodeInformationControl());
         _cDiagram.SelectModel(cNode1, false);
 
         // Executable Control

--- a/src/Blazor.Diagrams.Core/Controls/ControlsBehavior.cs
+++ b/src/Blazor.Diagrams.Core/Controls/ControlsBehavior.cs
@@ -5,57 +5,49 @@ namespace Blazor.Diagrams.Core.Controls;
 
 public class ControlsBehavior : Behavior
 {
-    public ControlsBehavior(Diagram diagram) : base(diagram)
-    {
-        Diagram.PointerEnter += OnPointerEnter;
-        Diagram.PointerLeave += OnPointerLeave;
-        Diagram.SelectionChanged += OnSelectionChanged;
-    }
+	public ControlsBehavior(Diagram diagram) : base(diagram)
+	{
+		Diagram.PointerEnter += OnPointerEnter;
+		Diagram.PointerLeave += OnPointerLeave;
+		Diagram.SelectionChanged += OnSelectionChanged;
+	}
 
-    private void OnSelectionChanged(SelectableModel model)
-    {
-        var controls = Diagram.Controls.GetFor(model);
-        if (controls is not { Type: ControlsType.OnSelection })
-            return;
+	private void OnSelectionChanged(SelectableModel model)
+	{
+		var controls = Diagram.Controls.GetFor(model, ControlsType.OnSelection);
+		if (controls is null)
+			return;
 
-        if (model.Selected)
-        {
-            controls.Show();
-        }
-        else
-        {
-            controls.Hide();
-        }
-    }
+		if (model.Selected)
+		{
+			controls.Show();
+		}
+		else
+		{
+			controls.Hide();
+		}
+	}
 
-    private void OnPointerEnter(Model? model, PointerEventArgs e)
-    {
-        if (model == null)
-            return;
-        
-        var controls = Diagram.Controls.GetFor(model);
-        if (controls is not { Type: ControlsType.OnHover })
-            return;
-        
-        controls.Show();
-    }
+	private void OnPointerEnter(Model? model, PointerEventArgs e)
+	{
+		if (model == null)
+			return;
 
-    private void OnPointerLeave(Model? model, PointerEventArgs e)
-    {
-        if (model == null)
-            return;
-        
-        var controls = Diagram.Controls.GetFor(model);
-        if (controls is not { Type: ControlsType.OnHover })
-            return;
-        
-        controls.Hide();
-    }
+		Diagram.Controls.GetFor(model, ControlsType.OnHover)?.Show();
+	}
 
-    public override void Dispose()
-    {
-        Diagram.PointerEnter -= OnPointerEnter;
-        Diagram.PointerLeave -= OnPointerLeave;
-        Diagram.SelectionChanged -= OnSelectionChanged;
-    }
+	private void OnPointerLeave(Model? model, PointerEventArgs e)
+	{
+		if (model == null)
+			return;
+
+		Diagram.Controls.GetFor(model, ControlsType.OnHover)?.Hide();
+	}
+
+	public override void Dispose()
+	{
+		Diagram.PointerEnter -= OnPointerEnter;
+		Diagram.PointerLeave -= OnPointerLeave;
+		Diagram.SelectionChanged -= OnSelectionChanged;
+	}
 }

--- a/src/Blazor.Diagrams.Core/Controls/ControlsContainer.cs
+++ b/src/Blazor.Diagrams.Core/Controls/ControlsContainer.cs
@@ -14,6 +14,8 @@ public class ControlsContainer : IReadOnlyList<Control>
     {
         Model = model;
         Type = type;
+
+        Visible = type == ControlsType.AlwaysOn;
     }
 
     public Model Model { get; }
@@ -24,7 +26,7 @@ public class ControlsContainer : IReadOnlyList<Control>
     {
         if (Visible)
             return;
-        
+
         Visible = true;
         VisibilityChanged?.Invoke(Model);
     }
@@ -33,7 +35,7 @@ public class ControlsContainer : IReadOnlyList<Control>
     {
         if (!Visible)
             return;
-        
+
         Visible = false;
         VisibilityChanged?.Invoke(Model);
     }

--- a/src/Blazor.Diagrams.Core/Controls/ControlsContainer.cs
+++ b/src/Blazor.Diagrams.Core/Controls/ControlsContainer.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using Blazor.Diagrams.Core.Models.Base;
 
 namespace Blazor.Diagrams.Core.Controls;
@@ -19,7 +17,7 @@ public class ControlsContainer : IReadOnlyList<Control>
     }
 
     public Model Model { get; }
-    public ControlsType Type { get; set; }
+    public ControlsType Type { get; init; }
     public bool Visible { get; private set; }
 
     public void Show()

--- a/src/Blazor.Diagrams.Core/Controls/ControlsLayer.cs
+++ b/src/Blazor.Diagrams.Core/Controls/ControlsLayer.cs
@@ -29,10 +29,9 @@ public class ControlsLayer
 
     public ControlsContainer? GetFor(Model model, ControlsType type)
     {
-        if (_containers.TryGetValue((model, type), out ControlsContainer? container))
-            return container;
+        _containers.TryGetValue((model, type), out ControlsContainer? container);
 
-        return null;
+        return container;
     }
 
     /// <summary>

--- a/src/Blazor.Diagrams.Core/Controls/ControlsLayer.cs
+++ b/src/Blazor.Diagrams.Core/Controls/ControlsLayer.cs
@@ -4,86 +4,106 @@ namespace Blazor.Diagrams.Core.Controls;
 
 public class ControlsLayer
 {
-	private readonly Dictionary<(Model Model, ControlsType Type), ControlsContainer> _containers = new();
+    private readonly Dictionary<(Model Model, ControlsType Type), ControlsContainer> _containers = new();
 
-	public event Action<Model>? ChangeCaused;
+    public event Action<Model>? ChangeCaused;
 
-	public IEnumerable<Model> Models => _containers.Keys.Select(key => key.Model);
-	public IEnumerable<(Model Model, ControlsType Type)> ContainersKeys => _containers.Keys;
+    public IEnumerable<Model> Models => _containers.Keys.Select(key => key.Model);
+    public IEnumerable<(Model Model, ControlsType Type)> ContainersKeys => _containers.Keys;
 
-	public ControlsContainer AddFor(Model model, ControlsType type = ControlsType.OnSelection)
-	{
-		var key = (model, type);
-		if (_containers.TryGetValue(key, out ControlsContainer? container))
-			return container;
+    public ControlsContainer AddFor(Model model, ControlsType type = ControlsType.OnSelection)
+    {
+        var key = (model, type);
+        if (_containers.TryGetValue(key, out ControlsContainer? container))
+            return container;
 
-		container = new(model, type);
-		container.VisibilityChanged += OnVisibilityChanged;
-		container.ControlsChanged += RefreshIfVisible;
-		model.Changed += RefreshIfVisible;
+        container = new(model, type);
+        container.VisibilityChanged += OnVisibilityChanged;
+        container.ControlsChanged += RefreshIfVisible;
+        model.Changed += RefreshIfVisible;
 
-		_containers.Add(key, container);
+        _containers.Add(key, container);
 
-		return container;
-	}
+        return container;
+    }
 
-	public ControlsContainer? GetFor(Model model, ControlsType type)
-	{
-		if (_containers.TryGetValue((model, type), out ControlsContainer? container))
-			return container;
+    public ControlsContainer? GetFor(Model model, ControlsType type)
+    {
+        if (_containers.TryGetValue((model, type), out ControlsContainer? container))
+            return container;
 
-		return null;
-	}
+        return null;
+    }
 
-	public bool RemoveFor(Model model, ControlsType type)
-	{
-		var key = (model, type);
-		if (!_containers.TryGetValue(key, out var container))
-			return false;
+    /// <summary>
+    /// Will return ALL registered containers for model. Null if no containers registered
+    /// </summary>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    public IReadOnlyCollection<ControlsContainer>? GetFor(Model model)
+    {
+        List<ControlsContainer>? containers = new();
+        foreach (ControlsType type in (ControlsType[])Enum.GetValues(typeof(ControlsType)))
+        {
+            if (_containers.TryGetValue((model, type), out ControlsContainer? container))
+                containers.Add(container);
+        }
 
-		container.VisibilityChanged -= OnVisibilityChanged;
-		container.ControlsChanged -= RefreshIfVisible;
-		model.Changed -= RefreshIfVisible;
-		_containers.Remove(key);
-		ChangeCaused?.Invoke(model);
-		return true;
-	}
+        if (containers.Count == 0)
+            return null;
 
-	public bool RemoveFor(Model model)
-	{
-		bool removed = false;
-		foreach (ControlsType type in (ControlsType[])Enum.GetValues(typeof(ControlsType)))
-		{
-			var key = (model, type);
-			if (_containers.TryGetValue(key, out var container))
-			{
-				container.VisibilityChanged -= OnVisibilityChanged;
-				container.ControlsChanged -= RefreshIfVisible;
-				model.Changed -= RefreshIfVisible;
-				_containers.Remove(key);
-				ChangeCaused?.Invoke(model);
-				removed = true;
-			}
+        return containers.AsReadOnly();
+    }
 
-		}
+    public bool RemoveFor(Model model, ControlsType type)
+    {
+        var key = (model, type);
+        if (!_containers.TryGetValue(key, out var container))
+            return false;
 
-		return removed;
-	}
+        container.VisibilityChanged -= OnVisibilityChanged;
+        container.ControlsChanged -= RefreshIfVisible;
+        model.Changed -= RefreshIfVisible;
+        _containers.Remove(key);
+        ChangeCaused?.Invoke(model);
+        return true;
+    }
 
-	public bool AreVisibleFor(Model model, ControlsType type) => GetFor(model, type)?.Visible ?? false;
+    public bool RemoveFor(Model model)
+    {
+        bool removed = false;
+        foreach (ControlsType type in (ControlsType[])Enum.GetValues(typeof(ControlsType)))
+        {
+            var key = (model, type);
+            if (_containers.TryGetValue(key, out var container))
+            {
+                container.VisibilityChanged -= OnVisibilityChanged;
+                container.ControlsChanged -= RefreshIfVisible;
+                model.Changed -= RefreshIfVisible;
+                _containers.Remove(key);
+                ChangeCaused?.Invoke(model);
+                removed = true;
+            }
 
-	private void RefreshIfVisible(Model cause)
-	{
-		foreach (ControlsType type in (ControlsType[])Enum.GetValues(typeof(ControlsType)))
-		{
-			if (AreVisibleFor(cause, type))
-			{
-				ChangeCaused?.Invoke(cause);
-				return;
-			}
-		}
+        }
 
-	}
+        return removed;
+    }
 
-	private void OnVisibilityChanged(Model cause) => ChangeCaused?.Invoke(cause);
+    public bool AreVisibleFor(Model model, ControlsType type) => GetFor(model, type)?.Visible ?? false;
+
+    private void RefreshIfVisible(Model cause)
+    {
+        foreach (ControlsType type in (ControlsType[])Enum.GetValues(typeof(ControlsType)))
+        {
+            if (AreVisibleFor(cause, type))
+            {
+                ChangeCaused?.Invoke(cause);
+                return;
+            }
+        }
+
+    }
+
+    private void OnVisibilityChanged(Model cause) => ChangeCaused?.Invoke(cause);
 }

--- a/src/Blazor.Diagrams.Core/Controls/ControlsLayer.cs
+++ b/src/Blazor.Diagrams.Core/Controls/ControlsLayer.cs
@@ -1,62 +1,89 @@
-using System;
-using System.Collections.Generic;
 using Blazor.Diagrams.Core.Models.Base;
 
 namespace Blazor.Diagrams.Core.Controls;
 
 public class ControlsLayer
 {
-    private readonly Dictionary<Model, ControlsContainer> _containers;
+	private readonly Dictionary<(Model Model, ControlsType Type), ControlsContainer> _containers = new();
 
-    public event Action<Model>? ChangeCaused;
+	public event Action<Model>? ChangeCaused;
 
-    public ControlsLayer()
-    {
-        _containers = new Dictionary<Model, ControlsContainer>();
-    }
+	public IEnumerable<Model> Models => _containers.Keys.Select(key => key.Model);
+	public IEnumerable<(Model Model, ControlsType Type)> ContainersKeys => _containers.Keys;
 
-    public IReadOnlyCollection<Model> Models => _containers.Keys;
+	public ControlsContainer AddFor(Model model, ControlsType type = ControlsType.OnSelection)
+	{
+		var key = (model, type);
+		if (_containers.TryGetValue(key, out ControlsContainer? container))
+			return container;
 
-    public ControlsContainer AddFor(Model model, ControlsType type = ControlsType.OnSelection)
-    {
-        if (_containers.ContainsKey(model))
-            return _containers[model];
-        
-        var container = new ControlsContainer(model, type);
-        container.VisibilityChanged += OnVisibilityChanged;
-        container.ControlsChanged += RefreshIfVisible;
-        model.Changed += RefreshIfVisible;
-        _containers.Add(model, container);
-        return container;
-    }
+		container = new(model, type);
+		container.VisibilityChanged += OnVisibilityChanged;
+		container.ControlsChanged += RefreshIfVisible;
+		model.Changed += RefreshIfVisible;
 
-    public ControlsContainer? GetFor(Model model)
-    {
-        return _containers.TryGetValue(model, out var container) ? container : null;
-    }
+		_containers.Add(key, container);
 
-    public bool RemoveFor(Model model)
-    {
-        if (!_containers.TryGetValue(model, out var container))
-            return false;
-        
-        container.VisibilityChanged -= OnVisibilityChanged;
-        container.ControlsChanged -= RefreshIfVisible;
-        model.Changed -= RefreshIfVisible;
-        _containers.Remove(model);
-        ChangeCaused?.Invoke(model);
-        return true;
-    }
+		return container;
+	}
 
-    public bool AreVisibleFor(Model model) => GetFor(model)?.Visible ?? false;
+	public ControlsContainer? GetFor(Model model, ControlsType type)
+	{
+		if (_containers.TryGetValue((model, type), out ControlsContainer? container))
+			return container;
 
-    private void RefreshIfVisible(Model cause)
-    {
-        if (!AreVisibleFor(cause))
-            return;
-        
-        ChangeCaused?.Invoke(cause);
-    }
+		return null;
+	}
 
-    private void OnVisibilityChanged(Model cause) => ChangeCaused?.Invoke(cause);
+	public bool RemoveFor(Model model, ControlsType type)
+	{
+		var key = (model, type);
+		if (!_containers.TryGetValue(key, out var container))
+			return false;
+
+		container.VisibilityChanged -= OnVisibilityChanged;
+		container.ControlsChanged -= RefreshIfVisible;
+		model.Changed -= RefreshIfVisible;
+		_containers.Remove(key);
+		ChangeCaused?.Invoke(model);
+		return true;
+	}
+
+	public bool RemoveFor(Model model)
+	{
+		bool removed = false;
+		foreach (ControlsType type in (ControlsType[])Enum.GetValues(typeof(ControlsType)))
+		{
+			var key = (model, type);
+			if (_containers.TryGetValue(key, out var container))
+			{
+				container.VisibilityChanged -= OnVisibilityChanged;
+				container.ControlsChanged -= RefreshIfVisible;
+				model.Changed -= RefreshIfVisible;
+				_containers.Remove(key);
+				ChangeCaused?.Invoke(model);
+				removed = true;
+			}
+
+		}
+
+		return removed;
+	}
+
+	public bool AreVisibleFor(Model model, ControlsType type) => GetFor(model, type)?.Visible ?? false;
+
+	private void RefreshIfVisible(Model cause)
+	{
+		foreach (ControlsType type in (ControlsType[])Enum.GetValues(typeof(ControlsType)))
+		{
+			if (AreVisibleFor(cause, type))
+			{
+				ChangeCaused?.Invoke(cause);
+				return;
+			}
+		}
+
+	}
+
+	private void OnVisibilityChanged(Model cause) => ChangeCaused?.Invoke(cause);
 }

--- a/src/Blazor.Diagrams.Core/Controls/ControlsType.cs
+++ b/src/Blazor.Diagrams.Core/Controls/ControlsType.cs
@@ -3,5 +3,6 @@ namespace Blazor.Diagrams.Core.Controls;
 public enum ControlsType
 {
     OnHover,
-    OnSelection
+    OnSelection,
+    AlwaysOn
 }

--- a/src/Blazor.Diagrams.Core/Layers/LinkLayer.cs
+++ b/src/Blazor.Diagrams.Core/Layers/LinkLayer.cs
@@ -1,6 +1,5 @@
 ﻿using Blazor.Diagrams.Core.Anchors;
 using Blazor.Diagrams.Core.Models.Base;
-using System.Linq;
 
 namespace Blazor.Diagrams.Core.Layers;
 
@@ -30,7 +29,7 @@ public class LinkLayer : BaseLayer<BaseLinkModel>
         link.TargetChanged -= OnLinkTargetChanged;
         
         Diagram.Controls.RemoveFor(link);
-        Remove(link.Links.ToList());
+        Remove(link.Links);
     }
 
     private static void OnLinkSourceChanged(BaseLinkModel link, Anchor old, Anchor @new)

--- a/src/Blazor.Diagrams/Components/Controls/ControlsLayerRenderer.razor
+++ b/src/Blazor.Diagrams/Components/Controls/ControlsLayerRenderer.razor
@@ -6,7 +6,7 @@
 
 	if (Svg && key.Model.IsSvg())
 	{
-		<g class="controls" data-model-type="@key.Model.GetType().Name" data-model-id="@key.Model.Id">
+		<g class="controls" data-model-type="@key.Model.GetType().Name" data-model-id="@key.Model.Id" @key="key">
 			@foreach (var control in controls)
 			{
 				var position = control.GetPosition(key.Model);
@@ -19,7 +19,7 @@
 	}
 	else if (!Svg && !key.Model.IsSvg())
 	{
-		<div class="controls" data-model-type="@key.Model.GetType().Name" data-model-id="@key.Model.Id">
+		<div class="controls" data-model-type="@key.Model.GetType().Name" data-model-id="@key.Model.Id" @key="key">
 			@foreach (var control in controls)
 			{
 				var position = control.GetPosition(key.Model);

--- a/src/Blazor.Diagrams/Components/Controls/ControlsLayerRenderer.razor
+++ b/src/Blazor.Diagrams/Components/Controls/ControlsLayerRenderer.razor
@@ -1,33 +1,33 @@
-@foreach (var model in BlazorDiagram.Controls.Models)
+@foreach (var key in BlazorDiagram.Controls.ContainersKeys)
 {
-    var controls = BlazorDiagram.Controls.GetFor(model)!;
-    if (!controls.Visible || controls.Count == 0)
-        continue;
+	var controls = BlazorDiagram.Controls.GetFor(key.Model, key.Type)!;
+	if (!controls.Visible || controls.Count == 0)
+		continue;
 
-    if (Svg && model.IsSvg())
-    {
-        <g class="controls" data-model-type="@model.GetType().Name" data-model-id="@model.Id">
-            @foreach (var control in controls)
-            {
-                var position = control.GetPosition(model);
-                if (position == null)
-                    continue;
+	if (Svg && key.Model.IsSvg())
+	{
+		<g class="controls" data-model-type="@key.Model.GetType().Name" data-model-id="@key.Model.Id">
+			@foreach (var control in controls)
+			{
+				var position = control.GetPosition(key.Model);
+				if (position == null)
+					continue;
 
-                @RenderControl(model, control, position, true)
-            }
-        </g>
-    }
-    else if (!Svg && !model.IsSvg())
-    {
-        <div class="controls" data-model-type="@model.GetType().Name" data-model-id="@model.Id">
-            @foreach (var control in controls)
-            {
-                var position = control.GetPosition(model);
-                if (position == null)
-                    continue;
+				@RenderControl(key.Model, control, position, true)
+			}
+		</g>
+	}
+	else if (!Svg && !key.Model.IsSvg())
+	{
+		<div class="controls" data-model-type="@key.Model.GetType().Name" data-model-id="@key.Model.Id">
+			@foreach (var control in controls)
+			{
+				var position = control.GetPosition(key.Model);
+				if (position == null)
+					continue;
 
-                @RenderControl(model, control, position, false)
-            }
-        </div>
-    }
+				@RenderControl(key.Model, control, position, false)
+			}
+		</div>
+	}
 }

--- a/src/Blazor.Diagrams/Components/Controls/ControlsLayerRenderer.razor.cs
+++ b/src/Blazor.Diagrams/Components/Controls/ControlsLayerRenderer.razor.cs
@@ -26,7 +26,7 @@ public partial class ControlsLayerRenderer : IDisposable
     protected override void OnInitialized()
     {
         BlazorDiagram.Controls.ChangeCaused += OnControlsChangeCaused;
-    }
+	}
 
     protected override bool ShouldRender()
     {

--- a/src/Blazor.Diagrams/Components/Controls/ControlsLayerRenderer.razor.cs
+++ b/src/Blazor.Diagrams/Components/Controls/ControlsLayerRenderer.razor.cs
@@ -52,27 +52,26 @@ public partial class ControlsLayerRenderer : IDisposable
 
 		return builder =>
 		{
-			var index = 0;
-			builder.OpenElement(index, svg ? "g" : "div");
-			builder.AddAttribute(++index, "class", $"{(control is ExecutableControl ? "executable " : "")}diagram-control {control.GetType().Name}");
+			builder.OpenElement(0, svg ? "g" : "div");
+			builder.AddAttribute(1, "class", $"{(control is ExecutableControl ? "executable " : "")}diagram-control {control.GetType().Name}");
 			if (svg)
 			{
-				builder.AddAttribute(++index, "transform", $"translate({position.X.ToInvariantString()} {position.Y.ToInvariantString()})");
+				builder.AddAttribute(2, "transform", $"translate({position.X.ToInvariantString()} {position.Y.ToInvariantString()})");
 			}
 			else
 			{
-				builder.AddAttribute(++index, "style", $"top: {position.Y.ToInvariantString()}px; left: {position.X.ToInvariantString()}px");
+				builder.AddAttribute(3, "style", $"top: {position.Y.ToInvariantString()}px; left: {position.X.ToInvariantString()}px");
 			}
 
 			if (control is ExecutableControl ec)
 			{
-				builder.AddAttribute(++index, "onpointerdown", EventCallback.Factory.Create<PointerEventArgs>(this, e => OnPointerDown(e, model, ec)));
-				builder.AddEventStopPropagationAttribute(++index, "onpointerdown", true);
+				builder.AddAttribute(4, "onpointerdown", EventCallback.Factory.Create<PointerEventArgs>(this, e => OnPointerDown(e, model, ec)));
+				builder.AddEventStopPropagationAttribute(5, "onpointerdown", true);
 			}
 
-			builder.OpenComponent(++index, componentType);
-			builder.AddAttribute(++index, "Control", control);
-			builder.AddAttribute(++index, "Model", model);
+			builder.OpenComponent(6, componentType);
+			builder.AddAttribute(7, "Control", control);
+			builder.AddAttribute(8, "Model", model);
 			builder.CloseComponent();
 			builder.CloseElement();
 		};

--- a/src/Blazor.Diagrams/Components/Controls/ControlsLayerRenderer.razor.cs
+++ b/src/Blazor.Diagrams/Components/Controls/ControlsLayerRenderer.razor.cs
@@ -47,38 +47,36 @@ public partial class ControlsLayerRenderer : IDisposable
     }
 
     private RenderFragment RenderControl(Model model, Control control, Point position, bool svg)
-    {
-        var componentType = BlazorDiagram.GetComponent(control.GetType());
-        if (componentType == null)
-            throw new BlazorDiagramsException(
-                $"A component couldn't be found for the user action {control.GetType().Name}");
+	{
+		var componentType = BlazorDiagram.GetComponent(control.GetType()) ?? throw new BlazorDiagramsException($"A component couldn't be found for the user action {control.GetType().Name}");
 
-        return builder =>
-        {
-            builder.OpenElement(0, svg ? "g" : "div");
-            builder.AddAttribute(1, "class",
-                $"{(control is ExecutableControl ? "executable " : "")}diagram-control {control.GetType().Name}");
-            if (svg)
-                builder.AddAttribute(2, "transform",
-                    $"translate({position.X.ToInvariantString()} {position.Y.ToInvariantString()})");
-            else
-                builder.AddAttribute(2, "style",
-                    $"top: {position.Y.ToInvariantString()}px; left: {position.X.ToInvariantString()}px");
+		return builder =>
+		{
+			var index = 0;
+			builder.OpenElement(index, svg ? "g" : "div");
+			builder.AddAttribute(++index, "class", $"{(control is ExecutableControl ? "executable " : "")}diagram-control {control.GetType().Name}");
+			if (svg)
+			{
+				builder.AddAttribute(++index, "transform", $"translate({position.X.ToInvariantString()} {position.Y.ToInvariantString()})");
+			}
+			else
+			{
+				builder.AddAttribute(++index, "style", $"top: {position.Y.ToInvariantString()}px; left: {position.X.ToInvariantString()}px");
+			}
 
-            if (control is ExecutableControl ec)
-            {
-                builder.AddAttribute(3, "onpointerdown",
-                    EventCallback.Factory.Create<PointerEventArgs>(this, e => OnPointerDown(e, model, ec)));
-                builder.AddEventStopPropagationAttribute(4, "onpointerdown", true);
-            }
+			if (control is ExecutableControl ec)
+			{
+				builder.AddAttribute(++index, "onpointerdown", EventCallback.Factory.Create<PointerEventArgs>(this, e => OnPointerDown(e, model, ec)));
+				builder.AddEventStopPropagationAttribute(++index, "onpointerdown", true);
+			}
 
-            builder.OpenComponent(5, componentType);
-            builder.AddAttribute(6, "Control", control);
-            builder.AddAttribute(7, "Model", model);
-            builder.CloseComponent();
-            builder.CloseElement();
-        };
-    }
+			builder.OpenComponent(++index, componentType);
+			builder.AddAttribute(++index, "Control", control);
+			builder.AddAttribute(++index, "Model", model);
+			builder.CloseComponent();
+			builder.CloseElement();
+		};
+	}
 
     private async Task OnPointerDown(PointerEventArgs e, Model model, ExecutableControl control)
     {


### PR DESCRIPTION
Refactor for `ControlsLayer`.

Now you can use multiple controls type for same model (OnHover AND/OR OnSelection AND/OR AlwaysOn).
I also added the "AlwaysOn" type, since I have already seen similar requests here. Well, I also needed a similar type for controls.

I used reflection (`foreach (ControlsType type in (ControlsType[])Enum.GetValues(typeof(ControlsType)))`) in some places for future refactor. if suddenly an additional type of controls is needed, which is not currently noticed, or if it is generally decided to use custom controls types.
I don`t think, if it will slow down performance a lot. If it`s not acceptable - i`ll rewrite it using 3 different lists.

Such a pull request is necessary to implement business requirements regarding the display of information on a node at the time of editing and the ability to use additional. buttons when selecting a node. However, the previous implementation limited our capabilities. I'm guessing that someone has already had a similar problem.

p.s. failed tests "DiagramCanvasTests" is not my fault. It was broken in "development" branch. 