### PR TITLE
Added "Classes" that is then consumed by LinkWidget to make custom links possible.

### DIFF
--- a/src/Blazor.Diagrams.Core/Models/LinkModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/LinkModel.cs
@@ -23,5 +23,6 @@ public class LinkModel : BaseLinkModel
 
     public string? Color { get; set; }
     public string? SelectedColor { get; set; }
+    public string? Classes { get; set; }
     public double Width { get; set; } = 2;
 }

--- a/src/Blazor.Diagrams/Components/LinkWidget.razor
+++ b/src/Blazor.Diagrams/Components/LinkWidget.razor
@@ -3,6 +3,7 @@
 @{
     var color = Link.Selected ? Link.SelectedColor ?? BlazorDiagram.Options.Links.DefaultSelectedColor : Link.Color ?? BlazorDiagram.Options.Links.DefaultColor;
     var result = Link.PathGeneratorResult;
+    var classes = Link.Classes ?? "";
     if (result == null)
         return;
 
@@ -13,7 +14,8 @@
 <path d="@d"
       stroke-width="@Link.Width.ToInvariantString()"
       fill="none"
-      stroke="@color" />
+      stroke="@color"
+      class="@classes" />
 
 @if (dnlb!.OngoingLink == null || dnlb.OngoingLink != Link)
 {


### PR DESCRIPTION
While i do prefer the [other solution](https://github.com/Blazor-Diagrams/Blazor.Diagrams/pull/386), this one avoids the usage of BaseLinkModel in favour of LinkModel.

Since we already accept "Color" in LinkModel, "Classes" should be fine here too.

Using CSS ":has" you are also able to target the `<g>` tag in this way if you want to:
```
::deep g.diagram-link:has(.custom-class) {
    // custom <g> tag css goes here.
}
```

This PR is in response to this one: https://github.com/Blazor-Diagrams/Blazor.Diagrams/pull/386