### PR TITLE
Multi-touch support

### DIFF
--- a/src/Blazor.Diagrams.Core/Behaviors/PanBehavior.cs
+++ b/src/Blazor.Diagrams.Core/Behaviors/PanBehavior.cs
@@ -6,9 +6,8 @@ namespace Blazor.Diagrams.Core.Behaviors;
 
 public class PanBehavior : Behavior
 {
-    private Point? _initialPan;
-    private double _lastClientX;
-    private double _lastClientY;
+    private readonly Dictionary<long, Point> _activePointers = new();
+    private CenterCircle? _lastPointerCircle;
 
     public PanBehavior(Diagram diagram) : base(diagram)
     {
@@ -22,40 +21,68 @@ public class PanBehavior : Behavior
         if (e.Button != (int)MouseEventButton.Left)
             return;
 
-        Start(model, e.ClientX, e.ClientY, e.ShiftKey);
+        Start(model, e.Client, e.ShiftKey, e.PointerId);
     }
 
-    private void OnPointerMove(Model? model, PointerEventArgs e) => Move(e.ClientX, e.ClientY);
+    private void OnPointerMove(Model? model, PointerEventArgs e) => Move(e.Client, e.PointerId);
 
-    private void OnPointerUp(Model? model, PointerEventArgs e) => End();
+    private void OnPointerUp(Model? model, PointerEventArgs e) => End(e.PointerId);
 
-    private void Start(Model? model, double clientX, double clientY, bool shiftKey)
+    private void Start(Model? model, Point client, bool shiftKey, long pointerId)
     {
-        if (!Diagram.Options.AllowPanning || model != null || shiftKey)
+        if (model != null || shiftKey)
             return;
 
-        _initialPan = Diagram.Pan;
-        _lastClientX = clientX;
-        _lastClientY = clientY;
+        _activePointers[pointerId] = client;
+
+        PointersChanged();
     }
 
-    private void Move(double clientX, double clientY)
+    private void Move(Point client, long pointerId)
     {
-        if (!Diagram.Options.AllowPanning || _initialPan == null)
+        if (_lastPointerCircle == null)
             return;
 
-        var deltaX = clientX - _lastClientX - (Diagram.Pan.X - _initialPan.X);
-        var deltaY = clientY - _lastClientY - (Diagram.Pan.Y - _initialPan.Y);
-        Diagram.UpdatePan(deltaX, deltaY);
-    }
-
-    private void End()
-    {
-        if (!Diagram.Options.AllowPanning)
+        if (_activePointers.ContainsKey(pointerId) is false)
             return;
 
-        _initialPan = null;
+        _activePointers[pointerId] = client;
+
+        var newPointerCircle = GetCurrentPointerCircle();
+
+        var zoomFactor = _lastPointerCircle.Value.Radius == 0 ? 1 : newPointerCircle.Radius / _lastPointerCircle.Value.Radius;
+        var deltaPan = newPointerCircle.Origin - _lastPointerCircle.Value.Origin;
+
+        Diagram.Batch(() =>
+        {
+            if (Diagram.Options.Zoom.Enabled)
+                Diagram.SetZoom(Diagram.Zoom * zoomFactor, zoomClientOrigin: newPointerCircle.Origin);
+            if (Diagram.Options.AllowPanning)
+                Diagram.UpdatePan(deltaPan.X, deltaPan.Y);
+        });
+
+        _lastPointerCircle = newPointerCircle;
     }
+
+    private void End(long pointerId)
+    {
+        _activePointers.Remove(pointerId);
+
+        if (_activePointers.Count is 0)
+            _lastPointerCircle = null;
+        else
+            PointersChanged();
+    }
+
+    private CenterCircle GetCurrentPointerCircle()
+    {
+        var centroid = Point.CalculateCentroid(_activePointers.Values) ?? Point.Zero;
+        var radius = _activePointers.Values.Average(p => p.DistanceTo(centroid));
+        return new(centroid, radius);
+    }
+
+    private void PointersChanged() =>
+        _lastPointerCircle = GetCurrentPointerCircle();
 
     public override void Dispose()
     {
@@ -63,4 +90,6 @@ public class PanBehavior : Behavior
         Diagram.PointerMove -= OnPointerMove;
         Diagram.PointerUp -= OnPointerUp;
     }
+
+    private record struct CenterCircle(Point Origin, double Radius);
 }

--- a/src/Blazor.Diagrams.Core/Behaviors/ZoomBehavior.cs
+++ b/src/Blazor.Diagrams.Core/Behaviors/ZoomBehavior.cs
@@ -28,24 +28,7 @@ public class ZoomBehavior : Behavior
         if (newZoom < 0 || newZoom == Diagram.Zoom)
             return;
 
-        // Other algorithms (based only on the changes in the zoom) don't work for our case
-        // This solution is taken as is from react-diagrams (ZoomCanvasAction)
-        var clientWidth = Diagram.Container.Width;
-        var clientHeight = Diagram.Container.Height;
-        var widthDiff = clientWidth * newZoom - clientWidth * oldZoom;
-        var heightDiff = clientHeight * newZoom - clientHeight * oldZoom;
-        var clientX = e.ClientX - Diagram.Container.Left;
-        var clientY = e.ClientY - Diagram.Container.Top;
-        var xFactor = (clientX - Diagram.Pan.X) / oldZoom / clientWidth;
-        var yFactor = (clientY - Diagram.Pan.Y) / oldZoom / clientHeight;
-        var newPanX = Diagram.Pan.X - widthDiff * xFactor;
-        var newPanY = Diagram.Pan.Y - heightDiff * yFactor;
-
-        Diagram.Batch(() =>
-        {
-            Diagram.SetPan(newPanX, newPanY);
-            Diagram.SetZoom(newZoom);
-        });
+        Diagram.SetZoom(newZoom, zoomClientOrigin: e.Client);
     }
 
     public override void Dispose()

--- a/src/Blazor.Diagrams.Core/Diagram.cs
+++ b/src/Blazor.Diagrams.Core/Diagram.cs
@@ -251,6 +251,42 @@ public abstract class Diagram
         Refresh();
     }
 
+    /// <summary>
+    /// Changes the zoom level with a given origin
+    /// </summary>
+    /// <param name="newZoom">New zoom</param>
+    /// <param name="zoomClientOrigin">The origin of the zoom. Where it will expand/contract from</param>
+    public void SetZoom(double newZoom, Point zoomClientOrigin)
+    {
+        if(Container is null)
+        {
+            SetZoom(newZoom);
+            return;
+        }
+
+        newZoom = Math.Clamp(newZoom, Options.Zoom.Minimum, Options.Zoom.Maximum);
+        var oldZoom = Zoom;
+
+        // Other algorithms (based only on the changes in the zoom) don't work for our case
+        // This solution is taken as is from react-diagrams (ZoomCanvasAction)
+        var clientWidth = Container.Width;
+        var clientHeight = Container.Height;
+        var widthDiff = clientWidth * newZoom - clientWidth * oldZoom;
+        var heightDiff = clientHeight * newZoom - clientHeight * oldZoom;
+        var clientX = zoomClientOrigin.X - Container.Left;
+        var clientY = zoomClientOrigin.Y - Container.Top;
+        var xFactor = (clientX - Pan.X) / oldZoom / clientWidth;
+        var yFactor = (clientY - Pan.Y) / oldZoom / clientHeight;
+        var newPanX = Pan.X - widthDiff * xFactor;
+        var newPanY = Pan.Y - heightDiff * yFactor;
+
+        Batch(() =>
+        {
+            SetPan(newPanX, newPanY);
+            SetZoom(newZoom);
+        });
+    }
+
     public void SetContainer(Rectangle newRect)
     {
         if (newRect.Equals(Container))

--- a/src/Blazor.Diagrams.Core/Events/MouseEventArgs.cs
+++ b/src/Blazor.Diagrams.Core/Events/MouseEventArgs.cs
@@ -1,3 +1,8 @@
-﻿namespace Blazor.Diagrams.Core.Events;
+﻿using Blazor.Diagrams.Core.Geometry;
 
-public record MouseEventArgs(double ClientX, double ClientY, long Button, long Buttons, bool CtrlKey, bool ShiftKey, bool AltKey);
+namespace Blazor.Diagrams.Core.Events;
+
+public record MouseEventArgs(double ClientX, double ClientY, long Button, long Buttons, bool CtrlKey, bool ShiftKey, bool AltKey)
+{
+    public Point Client => new(ClientX, ClientY);
+}

--- a/src/Blazor.Diagrams.Core/Geometry/Point.cs
+++ b/src/Blazor.Diagrams.Core/Geometry/Point.cs
@@ -59,4 +59,27 @@ public record Point
         x = X;
         y = Y;
     }
+
+    /// <summary>
+    /// Calculates the centroid of a set of points.
+    /// </summary>
+    /// <param name="points">The collection of points</param>
+    /// <returns>A <see cref="Point"/> instance with the centroid coordinates or <see langword="null"/> if there were no points.</returns>
+    public static Point? CalculateCentroid(IEnumerable<Point> points)
+    {
+        double sumX = 0, sumY = 0;
+        var count = 0;
+
+        foreach (var point in points)
+        {
+            sumX += point.X;
+            sumY += point.Y;
+            count++;
+        }
+
+        if (count is 0)
+            return null;
+
+        return new Point(sumX / count, sumY / count);
+    }
 }


### PR DESCRIPTION
This modification allows `PanBehavior` to handle multiple pointers at the same time.

When using a single pointer (mouse or single touch) it behaves in the same manner as before. When more than one pointer is used, it also gains the responsibility of zooming in/out the diagram if the pointers change distance (pinch to zoom)

Instead of adding the algorithms as private methods, I've added them as public methods in various locations. I have had copies of them as extension methods in my application anyway, so I thought other might find them useful as well. Do let me know if you think otherwise, or if there are better locations to put them!

Modifications:
* The `Point` class gained a `CalculateCentroid` static method to calculate the centroid of a set of points
* `MouseEventArgs` gained a `Client` property that combines `ClientX` and `ClientY` into a `Point`. A shortcut, basically
* The `Diagram` class gained an overload for the `SetZoom` method that accepts a `Point` to be used as the zoom origin. The logic was moved from `ZoomBehavior`
* `PanBehavior` got an overhaul to support multiple pointers

Things I'm unsure of:
Should the new `SetZoom` overload clamp by the Minimum and Maximum zoom? I see that the original `SetZoom` only clamps the Minimum, but I'm not sure why. Perhaps something to do with the fit to screen action?

Is it bothersome that `PanBehavior` now also has logic for zooming, while there's a separate `ZoomBehavior`?

My thought in doing it that way is that `ZoomBehavior` is better off handling just zoom by wheel events. Leaving `PanBehavior` to handle all pointer events. This way makes things simpler, because if I were to split the Pan and Zoom multi-touch logic, there would be a lot of duplicated code, as they're really closely related.

I see the following options:
1. Renaming each to something like `WheelZoomBehavior` and `PointersPanZoomBehavior`. So instead of naming the behavior as the actions they do, it would be a combination of the events they listen to and the actions they can perform based on them.
2. Adding comments to each to clarify the overlapping actions
3. Split by actions. Duplicate some of the new `PanBehavior` code into `ZoomBehavior` and make it listen to pointer events too
4. The way I did it is fine as is

Personally, I like option 1. But there's the impact of breaking code for people who reference these behavior directly in their codebase. Not sure how common that is, or if it's that significant. If it is significant, perhaps option 2? Would love some input about this

Closes Blazor-Diagrams/Blazor.Diagrams#512