### PR TITLE
Make GroupModel.UpdateDimensions() protected virtual

### DIFF
--- a/src/Blazor.Diagrams.Core/Models/GroupModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/GroupModel.cs
@@ -111,7 +111,7 @@ public class GroupModel : NodeModel
         }
     }
 
-    private bool UpdateDimensions()
+    protected virtual bool UpdateDimensions()
     {
         if (Children.Count == 0)
             return true;


### PR DESCRIPTION
This PR changes the visibility of the `UpdateDimensions()` method in GroupModel from `private` to `protected virtual`.
This allows developers to override the method in custom implementations to adapt how dimensions and positions are updated.

No breaking changes are introduced, as the default implementation remains the same.