### PR TITLE
fix: remove group controls on destroy

### DIFF
--- a/src/Blazor.Diagrams.Core/Layers/GroupLayer.cs
+++ b/src/Blazor.Diagrams.Core/Layers/GroupLayer.cs
@@ -45,5 +45,6 @@ public class GroupLayer : BaseLayer<GroupModel>
         Diagram.Links.Remove(group.Links.ToArray());
         group.Ungroup();
         group.Group?.RemoveChild(group);
+        Diagram.Controls.RemoveFor(group);
     }
 }


### PR DESCRIPTION
If a group has a control, and it is selected, deleting the group does not remove the control
This PR fix this (based on NodeLayer that do it fine)