### PR TITLE
feat: set Update Dimensions of GroupModel as virtual

### DIFF
--- a/src/Blazor.Diagrams.Core/Models/GroupModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/GroupModel.cs
@@ -95,7 +95,7 @@ public class GroupModel : NodeModel
         foreach (var child in children)
         {
             _children.Add(child);
-            child.Group = this; 
+            child.Group = this;
             child.SizeChanged += OnNodeChanged;
             child.Moving += OnNodeChanged;
         }
@@ -111,7 +111,7 @@ public class GroupModel : NodeModel
         }
     }
 
-    private bool UpdateDimensions()
+    public virtual bool UpdateDimensions()
     {
         if (Children.Count == 0)
             return true;


### PR DESCRIPTION
I would like to handle left/right padding and top/bottom padding differently
As it's a specific need, adding such system in the lib seems overkill, so I would like to be able to override UpdateDimensions  (I"m creating custom inherited classes of GroupModel)