### PR TITLE
Add a dash pattern property to the LinkModel

### DIFF
--- a/src/Blazor.Diagrams.Core/Models/LinkModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/LinkModel.cs
@@ -23,5 +23,11 @@ public class LinkModel : BaseLinkModel
 
     public string? Color { get; set; }
     public string? SelectedColor { get; set; }
+
+    /// <summary>
+    /// Set a value equal to values accepted by SVG's 'stroke-dasharray' attribute.
+    /// For example '5,5' will result in patter where the line is drawn for 5px and not drawn for another 5px.
+    /// </summary>
+    public string? DashPattern { get; set; }
     public double Width { get; set; } = 2;
 }

--- a/src/Blazor.Diagrams/Components/LinkWidget.razor
+++ b/src/Blazor.Diagrams/Components/LinkWidget.razor
@@ -10,10 +10,17 @@
     var d = result.FullPath.ToString();
 }
 
+@{
+	var extraPathAttributes = new Dictionary<string, object>();
+	if (!string.IsNullOrEmpty(Link.DashPattern))
+		extraPathAttributes["stroke-dasharray"] = Link.DashPattern;
+}
+
 <path d="@d"
       stroke-width="@Link.Width.ToInvariantString()"
       fill="none"
-      stroke="@color" />
+      stroke="@color" 
+      @attributes="extraPathAttributes"/>
 
 @if (dnlb?.OngoingLink == null || dnlb.OngoingLink != Link)
 {


### PR DESCRIPTION
Hello! 

First of all, thank you for all the work on this awesome library — it's been a pleasure to use.
I needed to create a dashed link line and noticed that while the model exposes Color and Width properties, there's currently no way to control the dash style directly. After digging into the code, I found that it's possible to achieve this via CSS, as demonstrated in [LandingShowcaseDiagram.razor.css](https://github.com/Blazor-Diagrams/Blazor.Diagrams/blob/492bec3b754def37506c1b93b466ab8b8c8b81ba/site/Site/Components/Landing/LandingShowcaseDiagram.razor.css#L4). 

I believe adding a property to control basic dash styling — similar to how color and width are handled — could be a helpful addition and save users some time. For more advanced cases like animated dashes, CSS could still be used.
Thanks again for the great work
