### PR TITLE
Handle Dispose exceptions

### DIFF
--- a/src/Blazor.Diagrams/Components/DiagramCanvas.razor.cs
+++ b/src/Blazor.Diagrams/Components/DiagramCanvas.razor.cs
@@ -29,15 +29,23 @@ public partial class DiagramCanvas : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        BlazorDiagram.Changed -= OnDiagramChanged;
+        try
+        {
+            BlazorDiagram.Changed -= OnDiagramChanged;
 
-        if (_reference == null)
-            return;
+            if (_reference == null)
+                return;
 
-        if (elementReference.Id != null)
-            await JSRuntime.UnobserveResizes(elementReference);
+            if (elementReference.Id != null && JSRuntime != null)
+                await JSRuntime.UnobserveResizes(elementReference);
 
-        _reference.Dispose();
+            _reference.Dispose();
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException || ex is OperationCanceledException)
+        {
+            // This exception is expected when the user navigates away from the page
+            // and the component is disposed. It can be ignored.
+        }
     }
 
     private string GetLayerStyle(int order)
@@ -56,12 +64,20 @@ public partial class DiagramCanvas : IAsyncDisposable
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await base.OnAfterRenderAsync(firstRender);
-
-        if (firstRender)
+        try
         {
-            BlazorDiagram.SetContainer(await JSRuntime.GetBoundingClientRect(elementReference));
-            await JSRuntime.ObserveResizes(elementReference, _reference!);
+            await base.OnAfterRenderAsync(firstRender);
+
+            if (firstRender)
+            {
+                BlazorDiagram.SetContainer(await JSRuntime.GetBoundingClientRect(elementReference));
+                await JSRuntime.ObserveResizes(elementReference, _reference!);
+            }
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException || ex is OperationCanceledException)
+        {
+            // This exception is expected when the user navigates away from the page
+            // and the component is disposed. It can be ignored
         }
     }
 

--- a/src/Blazor.Diagrams/Components/Renderers/GroupRenderer.cs
+++ b/src/Blazor.Diagrams/Components/Renderers/GroupRenderer.cs
@@ -8,6 +8,7 @@ using Blazor.Diagrams.Models;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 
 namespace Blazor.Diagrams.Components.Renderers;
 
@@ -53,17 +54,25 @@ public class GroupRenderer : ComponentBase, IDisposable
 
     protected override void OnAfterRender(bool firstRender)
     {
-        if (Size.Zero.Equals(Group.Size))
-            return;
-
-        // Update the port positions (and links) when the size of the group changes
-        // This will save us some JS trips as well as useless rerenders
-
-        if (_lastSize == null || !_lastSize.Equals(Group.Size))
+        try
         {
-            Group.ReinitializePorts();
-            Group.RefreshLinks();
-            _lastSize = Group.Size;
+            if (Size.Zero.Equals(Group.Size))
+                return;
+
+            // Update the port positions (and links) when the size of the group changes
+            // This will save us some JS trips as well as useless rerenders
+
+            if (_lastSize == null || !_lastSize.Equals(Group.Size))
+            {
+                Group.ReinitializePorts();
+                Group.RefreshLinks();
+                _lastSize = Group.Size;
+            }
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException || ex is OperationCanceledException)
+        {
+            // This exception is expected when the user navigates away from the page
+            // and the component is disposed. It can be ignored
         }
     }
 

--- a/src/Blazor.Diagrams/Components/Renderers/PortRenderer.cs
+++ b/src/Blazor.Diagrams/Components/Renderers/PortRenderer.cs
@@ -80,9 +80,17 @@ public class PortRenderer : ComponentBase, IDisposable
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (!Port.Initialized)
+        try
         {
-            await UpdateDimensions();
+            if (!Port.Initialized)
+            {
+                await UpdateDimensions();
+            }
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException || ex is OperationCanceledException)
+        {
+            // This exception is expected when the user navigates away from the page
+            // and the component is disposed. It can be ignored
         }
     }
 


### PR DESCRIPTION
Proposal to intercept exceptions when disposing components.
Adding checks for `null` and `try/catch` in **Dispose** methods and during **Rendering**.
Below is an exception example to be handled.

```
[ERR] Unhandled exception in circuit 'dQIPK23O_RFuJINsK-Aq9BIEWyzyITdAq6VK6OW-ZSc'.
Microsoft.JSInterop.JSDisconnectedException: JavaScript interop calls cannot be issued at this time. 
This is because the circuit has disconnected and is being disposed.
at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, CancellationToken 
cancellationToken, Object[] args)
at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, Object[] args)
at Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(IJSRuntime jsRuntime, String identifier, Object[] args)
at Blazor.Diagrams.Extensions.JSRuntimeExtensions.UnobserveResizes(IJSRuntime jsRuntime, ElementReference element)
at Blazor.Diagrams.Components.DiagramCanvas.DisposeAsync()
at Microsoft.AspNetCore.Components.RenderTree.Renderer.<>c__DisplayClass93_0.
<<Dispose>g__HandleAsyncExceptions|0>d.MoveNext()
```